### PR TITLE
some SPI Slave fixes

### DIFF
--- a/src/spislave.cpp
+++ b/src/spislave.cpp
@@ -66,9 +66,9 @@ void spi_slave_task(void *param) {
     uint8_t *messageSize = txbuf + 3;
     *messageSize = msg.MessageSize;
     memcpy(txbuf + HEADER_SIZE, &msg.Message, msg.MessageSize);
-    // calculate crc16 checksum, not used yet
-    // uint16_t *crc = (uint16_t *)txbuf;
-    //*crc = crc16_be(0, messageType, msg.MessageSize + HEADER_SIZE - 2);
+    // calculate crc16 checksum
+    uint16_t *crc = (uint16_t *)txbuf;
+    *crc = crc16_be(0, messageType, msg.MessageSize + HEADER_SIZE - 2);
 
     // set length for spi slave driver
     transaction_size = HEADER_SIZE + msg.MessageSize;

--- a/src/spislave.cpp
+++ b/src/spislave.cpp
@@ -155,7 +155,8 @@ void spi_enqueuedata(uint8_t messageType, MessageBuffer_t *message) {
   BaseType_t ret =
       xQueueSendToBack(SPISendQueue, (void *)message, (TickType_t)0);
   if (ret == pdTRUE) {
-    ESP_LOGI(TAG, "%d byte(s) enqueued for SPI interface", message->MessageSize);
+    ESP_LOGI(TAG, "%d byte(s) enqueued for SPI interface",
+             message->MessageSize);
   } else {
     ESP_LOGW(TAG, "SPI sendqueue is full");
   }


### PR DESCRIPTION
- sometimes the buffers were 4 bytes too large (if the size was already dividable by four)

- re-enable the CRC16 in the first two bytes of the metadata. Not sure why this was commented out during the integration, but we have seen flipped bits in our experiments connecting a TC65 terminal to a LoPy4 board, so we decided to add it. If somebody does not need it, they can just skip the first two bytes.
