### PR TITLE
v1.6.971

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -29,16 +29,17 @@ description = Paxcounter is a proof-of-concept ESP32 device for metering passeng
 
 [common]
 ; for release_version use max. 10 chars total, use any decimal format like "a.b.c"
-release_version = 1.6.97
+release_version = 1.6.971
 ; DEBUG LEVEL: For production run set to 0, otherwise device will leak RAM while running!
 ; 0=None, 1=Error, 2=Warn, 3=Info, 4=Debug, 5=Verbose
 debug_level = 0
 ; UPLOAD MODE: select esptool to flash via USB/UART, select custom to upload to cloud for OTA
-upload_protocol = esptool
-;upload_protocol = custom
+;upload_protocol = esptool
+upload_protocol = custom
 extra_scripts = pre:build.py
 keyfile = ota.conf
-platform_espressif32 = https://github.com/platformio/platform-espressif32.git#a7b1fe6
+platform_espressif32 = espressif32@1.5.0
+;platform_espressif32 = https://github.com/platformio/platform-espressif32.git#a7b1fe6
 board_build.partitions = min_spiffs.csv
 monitor_speed = 115200
 lib_deps_lora = 

--- a/platformio.ini
+++ b/platformio.ini
@@ -34,8 +34,8 @@ release_version = 1.6.971
 ; 0=None, 1=Error, 2=Warn, 3=Info, 4=Debug, 5=Verbose
 debug_level = 0
 ; UPLOAD MODE: select esptool to flash via USB/UART, select custom to upload to cloud for OTA
-;upload_protocol = esptool
-upload_protocol = custom
+upload_protocol = esptool
+;upload_protocol = custom
 extra_scripts = pre:build.py
 keyfile = ota.conf
 platform_espressif32 = espressif32@1.5.0

--- a/src/paxcounter.conf
+++ b/src/paxcounter.conf
@@ -74,7 +74,7 @@
 #define BME_TEMP_OFFSET                 5.0f    // Offset sensor on chip temp <-> ambient temp [default = 5°C]
 
 // OTA settings
-#define USE_OTA                         1       // Comment out to disable OTA update
+//#define USE_OTA                         1       // Comment out to disable OTA update
 #define WIFI_MAX_TRY                    5       // maximum number of wifi connect attempts for OTA update [default = 20]
 #define OTA_MAX_TRY                     5       // maximum number of attempts for OTA download and write to flash [default = 3]
 #define OTA_MIN_BATT                    3600    // minimum battery level for OTA [millivolt]


### PR DESCRIPTION
revert to platformio-espressif32 core v1.5.0, after detecting 50% packet loss on wifi and ble with current staging version (root cause yet unknown)