### PR TITLE
Fixed invalid OLED pin mapping for TTGO v1

### DIFF
--- a/src/hal/ttgov1.h
+++ b/src/hal/ttgov1.h
@@ -17,8 +17,8 @@
 #define HAS_BUTTON KEY_BUILTIN
 
 // Pins for I2C interface of OLED Display
-#define MY_OLED_SDA (15)
-#define MY_OLED_SCL (4)
+#define MY_OLED_SDA (4)
+#define MY_OLED_SCL (15)
 #define MY_OLED_RST (16)
 
 // Pins for LORA chip SPI interface come from board file, we need some


### PR DESCRIPTION
There was a wrong pin mapping for the OLED display of the TTGO v1 introduced in the last commit. Therefore the display was not working anymore. I changed it back to SDA on pin 4 and SCL on pin 15, so it works again.