### PR TITLE
Update heltecv2.h

### DIFF
--- a/src/hal/heltecv2.h
+++ b/src/hal/heltecv2.h
@@ -11,6 +11,13 @@
 //#define HAS_BME GPIO_NUM_21, GPIO_NUM_22 // SDA, SCL
 //#define BME_ADDR BME680_I2C_ADDR_PRIMARY // connect SDIO of BME680 to GND
 
+// Of cause, by default the board has no BME680 mounted 
+// a BME680 sensor board maybe connected to I2C (SDA = 4 , and SLC = 15)
+// second it worked if SDIO left unconnected and 0x77 as address was used
+//#define HAS_BME 4, 15 // SDA, SCL
+//#define BME_ADDR BME680_I2C_ADDR_SECONDARY // leave SDIO of BME680 unconnected
+ 
+
 #define HAS_LORA 1       // comment out if device shall not send data via LoRa
 #define CFG_sx1276_radio 1
 
@@ -19,8 +26,8 @@
 #define HAS_BUTTON KEY_BUILTIN                        // button "PROG" on board
 
 // Pins for I2C interface of OLED Display
-#define MY_OLED_SDA (21)
-#define MY_OLED_SCL (22)
+#define MY_OLED_SDA (4)    // original = 21
+#define MY_OLED_SCL (15)    // original = 22
 #define MY_OLED_RST (16)
 
 // Pins for LORA chip SPI interface come from board file, we need some


### PR DESCRIPTION
(i) Correction due to an error in the earlier pinout diagram of the heltect WIFI LoRa 32(V2).

OLED_SCL is conntected to 15   (former 21, wrong)
OLED_SDA is connected to 4     (former 22, wrong)

(ii) enable to connect BME680 sensor board via I2C (SDA = 4 , SCL = 15)

in platformio.ini additionally the lib_deps has to be changed to integrate BSEC lib.

lib_deps = 
    ${common.lib_deps_all}
    ${common.lib_deps_lora}
    ${common.lib_deps_display}
build_flags =  ${common.build_flags_all}

