### PR TITLE
Fix Beacons' MAC addresses conversion

### DIFF
--- a/src/macsniff.cpp
+++ b/src/macsniff.cpp
@@ -39,7 +39,7 @@ void printKey(const char *name, const uint8_t *key, uint8_t len, bool lsb) {
 uint64_t macConvert(uint8_t *paddr) {
   uint64_t *mac;
   mac = (uint64_t *)paddr;
-  return (__builtin_bswap64(*mac) >> 8);
+  return (__builtin_bswap64(*mac) >> 16);
 }
 
 bool mac_add(uint8_t *paddr, int8_t rssi, bool sniff_type) {


### PR DESCRIPTION
 for comparison in macsniff.cpp: shift by 16 bits instead of 8 bits

I observed the same as #342 .

I don't know, if the fix is really correct, but at least I am now able to identify beacons defined in beacons_array.h.