### PR TITLE
Fix i2c address for OLED on TTGOv1 (use 0x3C instead of 0x3D)

### DIFF
--- a/include/display.h
+++ b/include/display.h
@@ -8,7 +8,11 @@
 // settings for oled display library
 #define USE_BACKBUFFER 1
 #define MY_OLED OLED_128x64
-#define OLED_ADDR -1
+#ifdef MY_OLED_ADDR
+    #define OLED_ADDR MY_OLED_ADDR
+#else
+    #define OLED_ADDR -1
+#endif
 #define OLED_INVERT 0
 #define USE_HW_I2C 1
 

--- a/src/hal/ttgov1.h
+++ b/src/hal/ttgov1.h
@@ -31,6 +31,9 @@
 #define MY_OLED_SCL (15)
 #define MY_OLED_RST (16)
 
+// This board reports back the wrong I2C address, so we overwrite it here
+#define MY_OLED_ADDR 0x3C
+
 // Pins for LORA chip SPI interface come from board file, we need some
 // additional definitions for LMIC
 #define LORA_IO1  (33)


### PR DESCRIPTION
- addresses #573 
- waits for https://github.com/bitbank2/ss_oled/pull/26