### PR TITLE
Fix for #632 - LDF will recognize BLE dependency of OneBitDisplay correctly

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -109,6 +109,7 @@ build_flags_all =
     -mfix-esp32-psram-cache-issue
 
 [env]
+lib_ldf_mode = deep ; #632 Fixes compiler error with OneBitDisplay library
 framework = arduino
 board = esp32dev
 board_build.partitions = min_spiffs.csv


### PR DESCRIPTION
Fixes #632 