### PR TITLE
Fix: issue #639, if no LORA time source available and GPS time in fir…

### DIFF
--- a/src/loraconf_abp.cpp
+++ b/src/loraconf_abp.cpp
@@ -39,8 +39,8 @@ void setABPParameters() {
     // devices' ping slots. LMIC does not have an easy way to define set this
     // frequency and support for class B is spotty and untested, so this
     // frequency is not configured here.
-    #elif defined(CFG_us915)
-    // NA-US channels 0-71 are configured automatically
+    #elif defined(CFG_us915) || defined(CFG_au915)
+    // NA-US and AU channels 0-71 are configured automatically
     // but only one group of 8 should (a subband) should be active
     // TTN recommends the second sub band, 1 in a zero based count.
     // https://github.com/TheThingsNetwork/gateway-conf/blob/master/US-global_conf.json

--- a/src/timekeeper.cpp
+++ b/src/timekeeper.cpp
@@ -35,8 +35,10 @@ void calibrateTime(void) {
   timesync_request();
 #endif
 
-  // (only!) if we lost time, we try to fallback to local time source RTS or GPS
-  if (timeSource == _unsynced) {
+  // if no LORA timesource is available, or if we lost time, then fallback to
+  // local time source RTS or GPS
+  if (((!TIME_SYNC_LORASERVER) && (!TIME_SYNC_LORAWAN)) ||
+      (timeSource == _unsynced)) {
 
 // has RTC -> fallback to RTC time
 #ifdef HAS_RTC
@@ -47,7 +49,10 @@ void calibrateTime(void) {
 // no RTC -> fallback to GPS time
 #if (HAS_GPS)
     t = get_gpstime(&t_msec);
-    timeSource = _gps;
+    if (t) {
+      // only set time source to GPS if GPS time was actually valid
+      timeSource = _gps;
+    }
 #endif
 
     if (t)

--- a/src/timekeeper.cpp
+++ b/src/timekeeper.cpp
@@ -49,14 +49,10 @@ void calibrateTime(void) {
 // no RTC -> fallback to GPS time
 #if (HAS_GPS)
     t = get_gpstime(&t_msec);
-    if (t) {
-      // only set time source to GPS if GPS time was actually valid
-      timeSource = _gps;
-    }
+    timeSource = _gps;
 #endif
 
-    if (t)
-      setMyTime((uint32_t)t, t_msec, timeSource); // set time
+    setMyTime((uint32_t)t, t_msec, timeSource); // set time
 
   } // fallback
 


### PR DESCRIPTION
…st call is invalid, then time will never get updated from GPS

https://github.com/cyberman54/ESP32-Paxcounter/issues/639