### PR TITLE
Created Remotecommand for switching on/of ENS-Counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,10 @@ Send for example `8386` as Downlink on Port 2 to get battery status and time/dat
 
 	0 = disabled
 	1 = enabled [default]
+    
+0x18 set ENS counter on/off
+   0 = disabled (default)
+   1 = enabled
 
 0x80 get device configuration
 

--- a/README.md
+++ b/README.md
@@ -511,8 +511,8 @@ Send for example `8386` as Downlink on Port 2 to get battery status and time/dat
     
 0x18 set ENS counter on/off
 
-        0 = disabled (default)
-        1 = enabled
+    0 = disabled (default)
+    1 = enabled
 
 0x80 get device configuration
 

--- a/README.md
+++ b/README.md
@@ -510,8 +510,9 @@ Send for example `8386` as Downlink on Port 2 to get battery status and time/dat
 	1 = enabled [default]
     
 0x18 set ENS counter on/off
-   0 = disabled (default)
-   1 = enabled
+
+        0 = disabled (default)
+	1 = enabled
 
 0x80 get device configuration
 

--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ Send for example `8386` as Downlink on Port 2 to get battery status and time/dat
 0x18 set ENS counter on/off
 
         0 = disabled (default)
-	1 = enabled
+        1 = enabled
 
 0x80 get device configuration
 

--- a/include/cyclic.h
+++ b/include/cyclic.h
@@ -11,7 +11,7 @@
 #include "sds011read.h"
 #include "sdcard.h"
 
-extern Ticker cyclicTimer;
+extern Ticker housekeeper;
 
 void setCyclicIRQ(void);
 void doHousekeeping(void);

--- a/include/globals.h
+++ b/include/globals.h
@@ -82,10 +82,8 @@ typedef struct __attribute__((packed)) {
   uint8_t monitormode;   // 0=disabled, 1=enabled
   uint8_t runmode;       // 0=normal, 1=update
   uint8_t payloadmask;   // bitswitches for payload data
-
   uint8_t enscount;      // 0=disabled 1= enabled
-  char version[10];      // Firmware version
-  
+ 
 #ifdef HAS_BME680
   uint8_t bsecstate[BSEC_MAX_STATE_BLOB_SIZE + 1]; // BSEC state for BME680 sensor
 #endif

--- a/include/globals.h
+++ b/include/globals.h
@@ -84,8 +84,7 @@ typedef struct __attribute__((packed)) {
   uint8_t payloadmask;   // bitswitches for payload data
 
   uint8_t enscount;      // 0=disabled 1= enabled
-  char version[10];      // Firmware version
-  
+    
 #ifdef HAS_BME680
   uint8_t bsecstate[BSEC_MAX_STATE_BLOB_SIZE + 1]; // BSEC state for BME680 sensor
 #endif

--- a/include/globals.h
+++ b/include/globals.h
@@ -82,8 +82,10 @@ typedef struct __attribute__((packed)) {
   uint8_t monitormode;   // 0=disabled, 1=enabled
   uint8_t runmode;       // 0=normal, 1=update
   uint8_t payloadmask;   // bitswitches for payload data
+
   uint8_t enscount;      // 0=disabled 1= enabled
- 
+  char version[10];      // Firmware version
+  
 #ifdef HAS_BME680
   uint8_t bsecstate[BSEC_MAX_STATE_BLOB_SIZE + 1]; // BSEC state for BME680 sensor
 #endif

--- a/include/globals.h
+++ b/include/globals.h
@@ -80,6 +80,7 @@ typedef struct __attribute__((packed)) {
   uint8_t monitormode;   // 0=disabled, 1=enabled
   uint8_t runmode;       // 0=normal, 1=update
   uint8_t payloadmask;   // bitswitches for payload data
+  uint8_t enscount;      // 0=disabled 1= enabled
   char version[10];      // Firmware version
 #ifdef HAS_BME680
   uint8_t

--- a/src/blecsan.cpp
+++ b/src/blecsan.cpp
@@ -168,11 +168,12 @@ IRAM_ATTR void gap_callback_handler(esp_gap_ble_cb_event_t event,
 
           mac_add((uint8_t *)p->scan_rst.bda, p->scan_rst.rssi, MAC_SNIFF_BLE);
 
-#if (COUNT_ENS)
+      if (cfg.enscount){
       // check for ens signature
-      if (NULL != strstr((const char *)p->scan_rst.ble_adv, ensMagicBytes))
+        if (NULL != strstr((const char *)p->scan_rst.ble_adv, ensMagicBytes))
         cwa_mac_add(hashedmac);
-#endif
+      }
+
 
       /* to be improved in vendorfilter if:
       // you can search for elements in the payload using the

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -54,7 +54,7 @@ static void defaultConfig(configData_t *myconfig) {
   myconfig->monitormode = 0;              // 0=disabled, 1=enabled
   myconfig->payloadmask = PAYLOADMASK;    // all payload switched on
   myconfig->enscount =0; // 0= disabled, 1 = enabled
-  memcpy(myconfig->version, version, 10); // Firmware version [exactly 10 chars]
+  
 
 #ifdef HAS_BME680
   // initial BSEC state for BME680 sensor

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -47,6 +47,7 @@ static void defaultConfig(configData_t *myconfig) {
   myconfig->rgblum = RGBLUMINOSITY;       // RGB Led luminosity (0..100%)
   myconfig->monitormode = 0;              // 0=disabled, 1=enabled
   myconfig->payloadmask = PAYLOADMASK;    // all payload switched on
+  myconfig->enscount =0; // 0= disabled, 1 = enabled
   memcpy(myconfig->version, version, 10); // Firmware version [exactly 10 chars]
 
 #ifdef HAS_BME680

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -28,10 +28,8 @@ static uint8_t buffer[cfgLen + cfgLen2];
 // (configData_t cfg)]
 // 3. magicByte [cfgLen2 bytes, containing a fixed identifier]
 
-static void defaultConfig(configData_t *myconfig) {
+static void defaultConfig(configData_t *myconfig) {   //device factory settings
   memcpy(myconfig->version, &PROGVERSION, 10); // Firmware version
-
-  // device factory settings
   myconfig->loradr = LORADRDEFAULT; // 0-15, lora datarate, see paxcounter.conf
   myconfig->txpower = LORATXPOWDEFAULT; // 0-15, lora tx power
   myconfig->adrmode = 1;                // 0=disabled, 1=enabled
@@ -44,8 +42,7 @@ static void defaultConfig(configData_t *myconfig) {
   myconfig->wifichancycle =
       WIFI_CHANNEL_SWITCH_INTERVAL; // wifi channel switch cycle [seconds/100]
   myconfig->blescantime =
-      BLESCANINTERVAL /
-      10; // BT channel scan cycle [seconds/100], default 1 (= 10ms)
+      BLESCANINTERVAL /10; // BT channel scan cycle [seconds/100], default 1 (= 10ms)
   myconfig->blescan = 1;  // 0=disabled, 1=enabled
   myconfig->wifiscan = 1; // 0=disabled, 1=enabled
   myconfig->wifiant = 0;  // 0=internal, 1=external (for LoPy/LoPy4)
@@ -54,7 +51,6 @@ static void defaultConfig(configData_t *myconfig) {
   myconfig->monitormode = 0;              // 0=disabled, 1=enabled
   myconfig->payloadmask = PAYLOADMASK;    // all payload switched on
   myconfig->enscount =0; // 0= disabled, 1 = enabled
-  memcpy(myconfig->version, version, 10); // Firmware version [exactly 10 chars]
 
 #ifdef HAS_BME680
   // initial BSEC state for BME680 sensor

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -28,8 +28,10 @@ static uint8_t buffer[cfgLen + cfgLen2];
 // (configData_t cfg)]
 // 3. magicByte [cfgLen2 bytes, containing a fixed identifier]
 
-static void defaultConfig(configData_t *myconfig) {   //device factory settings
+static void defaultConfig(configData_t *myconfig) {
   memcpy(myconfig->version, &PROGVERSION, 10); // Firmware version
+
+  // device factory settings
   myconfig->loradr = LORADRDEFAULT; // 0-15, lora datarate, see paxcounter.conf
   myconfig->txpower = LORATXPOWDEFAULT; // 0-15, lora tx power
   myconfig->adrmode = 1;                // 0=disabled, 1=enabled
@@ -42,7 +44,8 @@ static void defaultConfig(configData_t *myconfig) {   //device factory settings
   myconfig->wifichancycle =
       WIFI_CHANNEL_SWITCH_INTERVAL; // wifi channel switch cycle [seconds/100]
   myconfig->blescantime =
-      BLESCANINTERVAL /10; // BT channel scan cycle [seconds/100], default 1 (= 10ms)
+      BLESCANINTERVAL /
+      10; // BT channel scan cycle [seconds/100], default 1 (= 10ms)
   myconfig->blescan = 1;  // 0=disabled, 1=enabled
   myconfig->wifiscan = 1; // 0=disabled, 1=enabled
   myconfig->wifiant = 0;  // 0=internal, 1=external (for LoPy/LoPy4)
@@ -51,6 +54,7 @@ static void defaultConfig(configData_t *myconfig) {   //device factory settings
   myconfig->monitormode = 0;              // 0=disabled, 1=enabled
   myconfig->payloadmask = PAYLOADMASK;    // all payload switched on
   myconfig->enscount =0; // 0= disabled, 1 = enabled
+  memcpy(myconfig->version, version, 10); // Firmware version [exactly 10 chars]
 
 #ifdef HAS_BME680
   // initial BSEC state for BME680 sensor

--- a/src/cyclic.cpp
+++ b/src/cyclic.cpp
@@ -7,7 +7,7 @@
 // Local logging tag
 static const char TAG[] = __FILE__;
 
-Ticker cyclicTimer;
+Ticker housekeeper;
 
 #if (HAS_SDS011)
 extern boolean isSDS011Active;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -265,11 +265,10 @@ void dp_drawPage(time_t t, bool nextpage) {
     else
       dp_printf("WIFI:off");
     if (cfg.blescan)
-#if (!COUNT_ENS)
-      dp_printf("BLTH:%-5d", macs_ble);
-#else
+        if (!cfg.enscount)
+            dp_printf("BLTH:%-5d", macs_ble);
+        else
       dp_printf(" CWA:%-5d", cwa_report());
-#endif
     else
       dp_printf(" BLTH:off");
 #elif ((WIFICOUNTER) && (!BLECOUNTER))
@@ -280,10 +279,10 @@ void dp_drawPage(time_t t, bool nextpage) {
 #elif ((!WIFICOUNTER) && (BLECOUNTER))
     if (cfg.blescan) {
       dp_printf("BLTH:%-5d", macs_ble);
-#if (COUNT_ENS)
-      dp_printf("(CWA:%d)", cwa_report());
-#endif
-    } else
+        if (cfg.enscount)
+            dp_printf("(CWA:%d)", cwa_report());
+    } 
+    else
       dp_printf("BLTH:off");
 #else
     dp_printf("Sniffer disabled");

--- a/src/hal/ttgov21new.h
+++ b/src/hal/ttgov21new.h
@@ -1,6 +1,6 @@
 // clang-format off
 // upload_speed 921600
-// board esp32dev
+// board ttgo-lora32-v21new
 
 #ifndef _TTGOV21NEW_H
 #define _TTGOV21NEW_H

--- a/src/hal/ttgov21new.h
+++ b/src/hal/ttgov21new.h
@@ -1,6 +1,6 @@
 // clang-format off
 // upload_speed 921600
-// board ttgo-lora32-v21new
+// board esp32dev
 
 #ifndef _TTGOV21NEW_H
 #define _TTGOV21NEW_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -486,7 +486,7 @@ void setup() {
 
   // cyclic function interrupts
   sendTimer.attach(cfg.sendcycle * 2, setSendIRQ);
-  cyclicTimer.attach(HOMECYCLE, setCyclicIRQ);
+  housekeeper.attach(HOMECYCLE, setCyclicIRQ);
 
 #if (TIME_SYNC_INTERVAL)
 

--- a/src/rcommand.cpp
+++ b/src/rcommand.cpp
@@ -339,27 +339,55 @@ void set_flush(uint8_t val[]) {
   // used to open receive window on LoRaWAN class a nodes
 };
 
-// assign previously defined functions to set of numeric remote commands
-// format: opcode, function, #bytes params,
-// flag (true = do make settings persistent / false = don't)
-//
-static const cmd_t table[] = {
-    {0x01, set_rssi, 1, true},          {0x02, set_countmode, 1, true},
-    {0x03, set_gps, 1, true},           {0x04, set_display, 1, true},
-    {0x05, set_loradr, 1, true},        {0x06, set_lorapower, 1, true},
-    {0x07, set_loraadr, 1, true},       {0x08, set_screensaver, 1, true},
-    {0x09, set_reset, 1, false},        {0x0a, set_sendcycle, 1, true},
-    {0x0b, set_wifichancycle, 1, true}, {0x0c, set_blescantime, 1, true},
-    {0x0d, set_vendorfilter, 1, false}, {0x0e, set_blescan, 1, true},
-    {0x0f, set_wifiant, 1, true},       {0x10, set_rgblum, 1, true},
-    {0x11, set_monitor, 1, true},       {0x12, set_beacon, 7, false},
-    {0x13, set_sensor, 2, true},        {0x14, set_payloadmask, 1, true},
-    {0x15, set_bme, 1, true},           {0x16, set_batt, 1, true},
-    {0x17, set_wifiscan, 1, true},      {0x80, get_config, 0, false},
-    {0x81, get_status, 0, false},       {0x83, get_batt, 0, false},
-    {0x84, get_gps, 0, false},          {0x85, get_bme, 0, false},
-    {0x86, get_time, 0, false},         {0x87, set_time, 0, false},
-    {0x99, set_flush, 0, false}};
+void set_enscount(uint8_t val[]) {
+  ESP_LOGI(TAG, "Remote command: set ENS_COUNT to %s",
+           val[0] ? "on" : "off");
+  cfg.enscount = val[0] ? 1 : 0;
+  if (val[0]) 
+      cfg.payloadmask |= SENSOR1_DATA;
+  else 
+      cfg.payloadmask &= ~SENSOR1_DATA;
+      
+ 
+}
+
+    // assign previously defined functions to set of numeric remote commands
+    // format: opcode, function, #bytes params,
+    // flag (true = do make settings persistent / false = don't)
+    //
+    static const cmd_t table[] = {
+        {0x01, set_rssi, 1, true},
+        {0x02, set_countmode, 1, true},
+        {0x03, set_gps, 1, true},
+        {0x04, set_display, 1, true},
+        {0x05, set_loradr, 1, true},
+        {0x06, set_lorapower, 1, true},
+        {0x07, set_loraadr, 1, true},
+        {0x08, set_screensaver, 1, true},
+        {0x09, set_reset, 1, false},
+        {0x0a, set_sendcycle, 1, true},
+        {0x0b, set_wifichancycle, 1, true},
+        {0x0c, set_blescantime, 1, true},
+        {0x0d, set_vendorfilter, 1, false},
+        {0x0e, set_blescan, 1, true},
+        {0x0f, set_wifiant, 1, true},
+        {0x10, set_rgblum, 1, true},
+        {0x11, set_monitor, 1, true},
+        {0x12, set_beacon, 7, false},
+        {0x13, set_sensor, 2, true},
+        {0x14, set_payloadmask, 1, true},
+        {0x15, set_bme, 1, true},
+        {0x16, set_batt, 1, true},
+        {0x17, set_wifiscan, 1, true},
+        {0x18, set_enscount, 1, true},
+		{0x80, get_config, 0, false},
+        {0x81, get_status, 0, false},
+        {0x83, get_batt, 0, false},
+        {0x84, get_gps, 0, false},
+        {0x85, get_bme, 0, false},
+        {0x86, get_time, 0, false},
+        {0x87, set_time, 0, false},
+        {0x99, set_flush, 0, false}};
 
 static const uint8_t cmdtablesize =
     sizeof(table) / sizeof(table[0]); // number of commands in command table

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -56,16 +56,18 @@ uint8_t *sensor_read(uint8_t sensor) {
 
     // insert user specific sensor data frames here
     // note: Sensor1 fields are used for ENS count, if ENS detection enabled
-#if (COUNT_ENS)
+#if COUNT_ENS
+if (cfg.enscount)
     payload.addCount(cwa_report(), MAC_SNIFF_BLE_CWA);
 #else
+   if(!cfg.enscount)   
     buf[0] = length;
     buf[1] = 0x01;
     buf[2] = 0x02;
     buf[3] = 0x03;
+    
 #endif
     break;
-
   case 2:
 
     buf[0] = length;


### PR DESCRIPTION
you can now use rcommand 0x18 for switching on/of ENS-Counting. Requires `#define COUNT_ENS 1` and `#define BLE_SCAN 1` in `paxcounter.conf`
enabling sets cfg.enscount to 1 and switch payloadmask to send cwa-counts via LoRa and swiches displaying cwa to ble.