### PR TITLE
v2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ LoLin32lite + [LoraNode32-Lite shield](https://github.com/hallard/LoLin32-Lite-L
 - Generic ESP32
 
 Depending on board hardware following features are supported:
+- LoRaWAN communication, supporting various payload formats (see enclosed .js converters)
+- MQTT communication via TCP/IP and Ethernet interface (note: payload transmitted over MQTT will be base64 encoded)
+- SPI serial communication to a local host
 - LED (shows power & status)
 - OLED Display (shows detailed status)
 - RGB LED (shows colorized status)
@@ -62,7 +65,6 @@ Depending on board hardware following features are supported:
 - Switch external power / battery
 - LED Matrix display (similar to [this 64x16 model](https://www.instructables.com/id/64x16-RED-LED-Marquee/), can be ordered on [Aliexpress](https://www.aliexpress.com/item/P3-75-dot-matrix-led-module-3-75mm-high-clear-top1-for-text-display-304-60mm/32616683948.html))
 - SD-card (see section SD-card here) for logging pax data
-- Ethernet interface for MQTT communication via TCP/IP
 
 Target platform must be selected in `platformio.ini`.<br>
 Hardware dependent settings (pinout etc.) are stored in board files in /hal directory. If you want to use a ESP32 board which is not yet supported, use hal file generic.h and tailor pin mappings to your needs. Pull requests for new boards welcome.<br>

--- a/include/mqttclient.h
+++ b/include/mqttclient.h
@@ -5,6 +5,7 @@
 #include "rcommand.h"
 #include <MQTT.h>
 #include <ETH.h>
+#include <mbedtls/base64.h>
 
 #ifndef MQTT_CLIENTNAME
 #define MQTT_CLIENTNAME clientId
@@ -17,8 +18,7 @@ uint32_t mqtt_queuewaiting(void);
 void mqtt_queuereset(void);
 void mqtt_client_task(void *param);
 int mqtt_connect(const char *my_host, const uint16_t my_port);
-void mqtt_callback(MQTTClient *client, char topic[], char payload[],
-                   int length);
+void mqtt_callback(MQTTClient *client, char *topic, char *payload, int length);
 void NetworkEvent(WiFiEvent_t event);
 esp_err_t mqtt_init(void);
 void mqtt_deinit(void);

--- a/include/reset.h
+++ b/include/reset.h
@@ -11,7 +11,8 @@
 
 void do_reset(bool warmstart);
 void do_after_reset(void);
-void enter_deepsleep(const uint64_t wakeup_sec, const gpio_num_t wakeup_gpio);
+void enter_deepsleep(const uint64_t wakeup_sec = 60,
+                     const gpio_num_t wakeup_gpio = GPIO_NUM_MAX);
 unsigned long long uptime(void);
 
 #endif // _RESET_H

--- a/platformio_orig.ini
+++ b/platformio_orig.ini
@@ -47,7 +47,7 @@ description = Paxcounter is a device for metering passenger flows in realtime. I
 
 [common]
 ; for release_version use max. 10 chars total, use any decimal format like "a.b.c"
-release_version = 2.1.0
+release_version = 2.1.1
 ; DEBUG LEVEL: For production run set to 0, otherwise device will leak RAM while running!
 ; 0=None, 1=Error, 2=Warn, 3=Info, 4=Debug, 5=Verbose
 debug_level = 3

--- a/src/hal/lopy4.h
+++ b/src/hal/lopy4.h
@@ -10,7 +10,6 @@
 // Hardware related definitions for Pycom LoPy4 Board
 
 #define HAS_LORA 1       // comment out if device shall not send data via LoRa
-#define LORA_RST  LMIC_UNUSED_PIN // reset pin of lora chip is not wired von LoPy4
 
 //#defin HAS_SPI 1        // comment out if device shall not send data via SPI
 // pin definitions for local wired SPI slave interface

--- a/src/lmic_config.h
+++ b/src/lmic_config.h
@@ -18,9 +18,10 @@
 
 // use interrupts only if LORA_IRQ and LORA_DIO are connected to interrupt
 // capable and separate GPIO pins on your board, if not don't enable
-#if (LORA_IRQ) != (LORA_IO1)
-#define LMIC_USE_INTERRUPTS 1
-#endif
+// note: this feature can't be used on ESP32 unless PR #556 of MCCI LMIC was merged
+//#if (LORA_IRQ) != (LORA_IO1)
+//#define LMIC_USE_INTERRUPTS 1
+//#endif
 
 // avoid lmic warning if we don't configure radio in case we haven't one
 #if !(defined(CFG_sx1272_radio) || defined(CFG_sx1276_radio))

--- a/src/reset.cpp
+++ b/src/reset.cpp
@@ -81,8 +81,7 @@ void do_after_reset(void) {
            runmode[RTC_runmode]);
 }
 
-void enter_deepsleep(const uint64_t wakeup_sec = 60,
-                     gpio_num_t wakeup_gpio = GPIO_NUM_MAX) {
+void enter_deepsleep(const uint64_t wakeup_sec, gpio_num_t wakeup_gpio) {
 
   ESP_LOGI(TAG, "Preparing to sleep...");
 


### PR DESCRIPTION
MQTT client reworked:
- Added base64 encoding
- Repair rcommand processing over MQTT

Bugfixes:
- remove redundant LORA_RST pin definition from lopy4.h
- fix compiler error occuring with enter_deepsleep() for devices without button
- remove DIO IRQ support, while not safely introduced for ESP32 in MCCI LMIC (see PR #556 there)