### PR TITLE
Enrich the debug-level log message with reading of timestamp at program compilation as well as GPS time reading when the board time fails to sync with GPS.

### DIFF
--- a/src/gpsread.cpp
+++ b/src/gpsread.cpp
@@ -119,8 +119,8 @@ time_t get_gpstime(uint16_t *msec) {
     tm.Year = CalendarYrToTm(atoi(gpsyear.value())); // year offset from 1970
     t = makeTime(tm);
 
-    // ESP_LOGD(TAG, "GPS time/date = %2d:%2d:%2d / %2d.%2d.%2d", tm.Hour,
-    //         tm.Minute, tm.Second, tm.Day, tm.Month, tm.Year + 1970);
+    ESP_LOGD(TAG, "GPS time/date = %2d:%2d:%2d / %2d.%2d.%2d", tm.Hour,
+            tm.Minute, tm.Second, tm.Day, tm.Month, tm.Year + 1970);
 
     // add protocol delay with millisecond precision
     t += delay_ms / 1000 - 1; // whole seconds

--- a/src/timekeeper.cpp
+++ b/src/timekeeper.cpp
@@ -109,8 +109,9 @@ void IRAM_ATTR setMyTime(uint32_t t_sec, uint16_t t_msec,
              _seconds(), timeSetSymbols[mytimesource]);
   } else {
     timesyncer.attach(TIME_SYNC_INTERVAL_RETRY * 60, setTimeSyncIRQ);
-    ESP_LOGD(TAG, "[%0.3f] Timesync failed, invalid time fetched | source: %c",
-             _seconds(), timeSetSymbols[mytimesource]);
+    time_t unix_sec_at_compilation = compiledUTC();
+    ESP_LOGD(TAG, "[%0.3f] Failed to synchronise time from source %c | unix sec obtained from source: %d | unix sec at program compilation: %d",
+             _seconds(), timeSetSymbols[mytimesource], time_to_set, unix_sec_at_compilation);
   }
 }
 


### PR DESCRIPTION
This helps user to debug time synchronisation failure stemmed from
a mismatch of developer's time zone and board's time zone.