### PR TITLE
Increase release version from 2.1.1 to 2.2.0.

### DIFF
--- a/platformio_orig.ini
+++ b/platformio_orig.ini
@@ -47,7 +47,7 @@ description = Paxcounter is a device for metering passenger flows in realtime. I
 
 [common]
 ; for release_version use max. 10 chars total, use any decimal format like "a.b.c"
-release_version = 2.1.1
+release_version = 2.2.0
 ; DEBUG LEVEL: For production run set to 0, otherwise device will leak RAM while running!
 ; 0=None, 1=Error, 2=Warn, 3=Info, 4=Debug, 5=Verbose
 debug_level = 3


### PR DESCRIPTION
This is necessary after having changed the payload type definition bits recently.
By increasing the release number, the setup function will erase memorised and non-compatible enabled payload bits.