### PR TITLE
Adapt global settings for BLE and WiFi counters.

### DIFF
--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -48,8 +48,8 @@ static void defaultConfig(configData_t *myconfig) {
   myconfig->blescantime =
       BLESCANINTERVAL /
       10; // BT channel scan cycle [seconds/100], default 1 (= 10ms)
-  myconfig->blescan = 1;            // 0=disabled, 1=enabled
-  myconfig->wifiscan = 1;           // 0=disabled, 1=enabled
+  myconfig->blescan = BLECOUNTER;    // 0=disabled, 1=enabled
+  myconfig->wifiscan = WIFICOUNTER; // 0=disabled, 1=enabled
   myconfig->wifiant = 0;            // 0=internal, 1=external (for LoPy/LoPy4)
   myconfig->macfilter = MACFILTER;  // 0=disabled, 1=enabled
   myconfig->rgblum = RGBLUMINOSITY; // RGB Led luminosity (0..100%)


### PR DESCRIPTION
I think it makes sense to adapt the global settings for BLE and WiFi counters as defaults.