### PR TITLE
libpax integration

### DIFF
--- a/build.py
+++ b/build.py
@@ -118,7 +118,7 @@ def publish_bintray(source, target, env):
     firmware_path = str(source[0])
     firmware_name = basename(firmware_path)
     url = "/".join([
-        "https://api.bintray.com", "content",
+        "https://pax.express", "content",
         user, repository, package, version, firmware_name
     ])
 

--- a/include/cyclic.h
+++ b/include/cyclic.h
@@ -12,6 +12,9 @@
 #include "sdcard.h"
 #include "macsniff.h"
 #include "reset.h"
+#ifdef LIBPAX
+#include <libpax_api.h>
+#endif
 
 extern Ticker cyclicTimer;
 

--- a/include/cyclic.h
+++ b/include/cyclic.h
@@ -12,7 +12,7 @@
 #include "sdcard.h"
 #include "macsniff.h"
 #include "reset.h"
-#ifdef LIBPAX
+#if LIBPAX
 #include <libpax_api.h>
 #endif
 

--- a/include/globals.h
+++ b/include/globals.h
@@ -141,6 +141,9 @@ extern uint8_t volatile channel;               // wifi channel rotation counter
 extern uint8_t volatile rf_load;               // RF traffic indicator
 extern uint8_t batt_level;                     // display value
 extern uint16_t volatile macs_wifi, macs_ble;  // display values
+#ifdef LIBPAX
+extern uint16_t volatile libpax_macs_ble, libpax_macs_wifi; // libpax values
+#endif
 extern bool volatile TimePulseTick; // 1sec pps flag set by GPS or RTC
 extern timesource_t timeSource;
 extern hw_timer_t *displayIRQ, *matrixDisplayIRQ, *ppsIRQ;

--- a/include/globals.h
+++ b/include/globals.h
@@ -141,7 +141,7 @@ extern uint8_t volatile channel;               // wifi channel rotation counter
 extern uint8_t volatile rf_load;               // RF traffic indicator
 extern uint8_t batt_level;                     // display value
 extern uint16_t volatile macs_wifi, macs_ble;  // display values
-#ifdef LIBPAX
+#if LIBPAX
 extern uint16_t volatile libpax_macs_ble, libpax_macs_wifi; // libpax values
 #endif
 extern bool volatile TimePulseTick; // 1sec pps flag set by GPS or RTC

--- a/include/libpax_helpers.h
+++ b/include/libpax_helpers.h
@@ -1,0 +1,10 @@
+#ifndef _LIBPAX_HELPERS_H
+#define _LIBPAX_HELPERS_H
+
+#include "globals.h"
+#include <stdio.h>
+#include <libpax_api.h>
+
+void init_libpax();
+
+#endif

--- a/include/senddata.h
+++ b/include/senddata.h
@@ -14,7 +14,7 @@
 #include "corona.h"
 #endif
 
-#if (LIBPAX)
+#if LIBPAX
 #include <libpax_api.h>
 
 extern struct count_payload_t count_from_libpax;

--- a/include/senddata.h
+++ b/include/senddata.h
@@ -9,9 +9,17 @@
 #include "display.h"
 #include "sdcard.h"
 
+
 #if (COUNT_ENS)
 #include "corona.h"
 #endif
+
+#if (LIBPAX)
+#include <libpax_api.h>
+
+extern struct count_payload_t count_from_libpax;
+#endif
+
 
 extern Ticker sendTimer;
 

--- a/lib/BintrayClient/src/BintrayClient.cpp
+++ b/lib/BintrayClient/src/BintrayClient.cpp
@@ -24,12 +24,9 @@
 
 BintrayClient::BintrayClient(const String &user, const String &repository, const String &package)
     : m_user(user), m_repo(repository), m_package(package),
-      m_storage_host("dl.bintray.com"),
-      m_api_host("api.bintray.com")
+      m_storage_host("pax.express"),
+      m_api_host("pax.express")
 {
-    m_certificates.emplace_back("cloudfront.net", CLOUDFRONT_API_ROOT_CA);
-    m_certificates.emplace_back("akamai.bintray.com", BINTRAY_AKAMAI_ROOT_CA);
-    m_certificates.emplace_back("bintray.com", BINTRAY_API_ROOT_CA);
 }
 
 String BintrayClient::getUser() const
@@ -83,7 +80,7 @@ String BintrayClient::requestHTTPContent(const String &url) const
 {
     String payload;
     HTTPClient http;
-    http.begin(url, getCertificate(url));
+    http.begin(url);
     int httpCode = http.GET();
 
     if (httpCode > 0)

--- a/platformio_orig.ini
+++ b/platformio_orig.ini
@@ -89,7 +89,7 @@ lib_deps_basic =
     lewisxhe/AXP202X_Library @ ^1.1.3
     geeksville/esp32-micro-sdcard @ ^0.1.1
     256dpi/MQTT @ ^2.4.7
-    https://github.com/dbSuS/libpax
+    https://github.com/dbSuS/libpax#v0.1.1
 lib_deps_all =
     ${common.lib_deps_basic}
     ${common.lib_deps_lora}

--- a/platformio_orig.ini
+++ b/platformio_orig.ini
@@ -89,6 +89,7 @@ lib_deps_basic =
     lewisxhe/AXP202X_Library @ ^1.1.3
     geeksville/esp32-micro-sdcard @ ^0.1.1
     256dpi/MQTT @ ^2.4.7
+    https://github.com/dbSuS/libpax
 lib_deps_all =
     ${common.lib_deps_basic}
     ${common.lib_deps_lora}
@@ -105,6 +106,9 @@ build_flags_basic =
     '-DPROGVERSION="${common.release_version}"'
     '-Wno-unknown-pragmas'
     '-Wno-unused-variable'
+    '-D LIBPAX_WIFI'
+    '-D LIBPAX_BLE'
+    '-D LIBPAX_ARDUINO'
 build_flags_sensors =
     -Llib/Bosch-BSEC/src/esp32/
     -lalgobsec

--- a/src/blecsan.cpp
+++ b/src/blecsan.cpp
@@ -1,3 +1,4 @@
+#ifndef LIBPAX
 // some code snippets taken from
 // https://github.com/nkolban/esp32-snippets/tree/master/BLE/scanner
 
@@ -300,3 +301,4 @@ void stop_BLEscan(void) {
   ESP_LOGI(TAG, "Bluetooth scanner stopped");
 #endif // BLECOUNTER
 } // stop_BLEscan
+#endif

--- a/src/blecsan.cpp
+++ b/src/blecsan.cpp
@@ -1,4 +1,4 @@
-#ifndef LIBPAX
+#if !(LIBPAX)
 // some code snippets taken from
 // https://github.com/nkolban/esp32-snippets/tree/master/BLE/scanner
 

--- a/src/cyclic.cpp
+++ b/src/cyclic.cpp
@@ -136,7 +136,7 @@ uint32_t getFreeRAM() {
 void reset_counters() {
 
 #if ((WIFICOUNTER) || (BLECOUNTER))
-#ifndef LIBPAX   
+#if !(LIBPAX)   
   macs.clear(); // clear all macs container
   macs_wifi = 0;
   macs_ble = 0;

--- a/src/cyclic.cpp
+++ b/src/cyclic.cpp
@@ -134,11 +134,14 @@ uint32_t getFreeRAM() {
 }
 
 void reset_counters() {
+
 #if ((WIFICOUNTER) || (BLECOUNTER))
+#ifndef LIBPAX   
   macs.clear(); // clear all macs container
   macs_wifi = 0;
   macs_ble = 0;
-  renew_salt(); // get new salt
+  renew_salt(); // get new salt 
+#endif
 #ifdef HAS_DISPLAY
   dp_plotCurve(0, true);
 #endif

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -262,7 +262,11 @@ void dp_drawPage(time_t t, bool nextpage) {
 
 #if ((WIFICOUNTER) && (BLECOUNTER))
     if (cfg.wifiscan)
+#ifndef LIBPAX
       dp_printf("WIFI:%-5d", macs_wifi);
+#else
+      dp_printf("WIFI:%-5d", libpax_macs_wifi);
+#endif
     else
       dp_printf("WIFI:off");
     if (cfg.blescan)
@@ -271,17 +275,29 @@ void dp_drawPage(time_t t, bool nextpage) {
         dp_printf(" CWA:%-5d", cwa_report());
       else
 #endif
-        dp_printf("BLTH:%-5d", macs_ble);
+#ifndef LIBPAX
+      dp_printf("BLTH:%-5d", macs_ble);
+#else
+      dp_printf("BLTH:%-5d", libpax_macs_ble);
+#endif
     else
       dp_printf(" BLTH:off");
 #elif ((WIFICOUNTER) && (!BLECOUNTER))
     if (cfg.wifiscan)
+#ifndef LIBPAX
       dp_printf("WIFI:%-5d", macs_wifi);
+#else
+      dp_printf("WIFI:%-5d", libpax_macs_wifi);
+#endif
     else
       dp_printf("WIFI:off");
 #elif ((!WIFICOUNTER) && (BLECOUNTER))
     if (cfg.blescan)
+#ifndef LIBPAX
       dp_printf("BLTH:%-5d", macs_ble);
+#else
+      dp_printf("BLTH:%-5d", libpax_macs_ble);
+#endif
 #if (COUNT_ENS)
     if (cfg.enscount)
       dp_printf("(CWA:%d)", cwa_report());

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -262,7 +262,7 @@ void dp_drawPage(time_t t, bool nextpage) {
 
 #if ((WIFICOUNTER) && (BLECOUNTER))
     if (cfg.wifiscan)
-#ifndef LIBPAX
+#if !(LIBPAX)   
       dp_printf("WIFI:%-5d", macs_wifi);
 #else
       dp_printf("WIFI:%-5d", libpax_macs_wifi);
@@ -275,7 +275,7 @@ void dp_drawPage(time_t t, bool nextpage) {
         dp_printf(" CWA:%-5d", cwa_report());
       else
 #endif
-#ifndef LIBPAX
+#if !(LIBPAX)   
       dp_printf("BLTH:%-5d", macs_ble);
 #else
       dp_printf("BLTH:%-5d", libpax_macs_ble);
@@ -284,7 +284,7 @@ void dp_drawPage(time_t t, bool nextpage) {
       dp_printf(" BLTH:off");
 #elif ((WIFICOUNTER) && (!BLECOUNTER))
     if (cfg.wifiscan)
-#ifndef LIBPAX
+#if !(LIBPAX)   
       dp_printf("WIFI:%-5d", macs_wifi);
 #else
       dp_printf("WIFI:%-5d", libpax_macs_wifi);
@@ -293,7 +293,7 @@ void dp_drawPage(time_t t, bool nextpage) {
       dp_printf("WIFI:off");
 #elif ((!WIFICOUNTER) && (BLECOUNTER))
     if (cfg.blescan)
-#ifndef LIBPAX
+#if !(LIBPAX)   
       dp_printf("BLTH:%-5d", macs_ble);
 #else
       dp_printf("BLTH:%-5d", libpax_macs_ble);

--- a/src/libpax_helpers.cpp
+++ b/src/libpax_helpers.cpp
@@ -1,7 +1,7 @@
 #include "libpax_helpers.h"
 
 // libpax payload
-#ifdef LIBPAX
+#if LIBPAX
 struct count_payload_t count_from_libpax;
 uint16_t volatile libpax_macs_ble, libpax_macs_wifi;
 

--- a/src/libpax_helpers.cpp
+++ b/src/libpax_helpers.cpp
@@ -1,0 +1,18 @@
+#include "libpax_helpers.h"
+
+// libpax payload
+#ifdef LIBPAX
+struct count_payload_t count_from_libpax;
+uint16_t volatile libpax_macs_ble, libpax_macs_wifi;
+
+void process_count(void) {
+  printf("pax: %d; %d; %d;\n", count_from_libpax.pax, count_from_libpax.wifi_count, count_from_libpax.ble_count);
+  libpax_macs_ble = count_from_libpax.ble_count;
+  libpax_macs_wifi = count_from_libpax.wifi_count;
+}
+
+void init_libpax() {
+      libpax_counter_init(process_count, &count_from_libpax, 60*1000, 1); 
+      libpax_counter_start();
+}
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,6 +86,7 @@ triggers pps 1 sec impulse
 
 // Basic Config
 #include "main.h"
+#include "libpax_helpers.h"
 
 configData_t cfg; // struct holds current device configuration
 char lmic_event_msg[LMIC_EVENTMSG_LEN]; // display buffer for LMIC event message
@@ -96,8 +97,6 @@ uint8_t volatile channel = WIFI_CHANNEL_MIN;   // channel rotation counter
 uint8_t volatile rf_load = 0;                  // RF traffic indicator
 #ifndef LIBPAX
 uint16_t volatile macs_wifi = 0, macs_ble = 0; // globals for display
-#else
-uint16_t volatile libpax_macs_ble, libpax_macs_wifi;
 #endif
 
 hw_timer_t *ppsIRQ = NULL, *displayIRQ = NULL, *matrixDisplayIRQ = NULL;
@@ -119,16 +118,6 @@ TimeChangeRule myDST = DAYLIGHT_TIME;
 TimeChangeRule mySTD = STANDARD_TIME;
 Timezone myTZ(myDST, mySTD);
 
-// libpax payload
-#ifdef LIBPAX
-struct count_payload_t count_from_libpax;
-
-void process_count(void) {
-  printf("pax: %d; %d; %d;\n", count_from_libpax.pax, count_from_libpax.wifi_count, count_from_libpax.ble_count);
-  libpax_macs_ble = count_from_libpax.ble_count;
-  libpax_macs_wifi = count_from_libpax.wifi_count;
-}
-#endif
 
 // local Tag for logging
 static const char TAG[] = __FILE__;
@@ -340,8 +329,7 @@ ESP_LOGI(TAG, "Starting libpax...");
     if(config_update != 0) {
       ESP_LOGE(TAG, "Error in libpax configuration.");
     } else {
-      libpax_counter_init(process_count, &count_from_libpax, 60*1000, 1); 
-      libpax_counter_start();
+      init_libpax();
     }
   } else {
     ESP_LOGE(TAG, "Error in libpax configuration: Wifi and BLE are not supported at the same time!");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -91,11 +91,11 @@ triggers pps 1 sec impulse
 configData_t cfg; // struct holds current device configuration
 char lmic_event_msg[LMIC_EVENTMSG_LEN]; // display buffer for LMIC event message
 uint8_t batt_level = 0;                 // display value
-#ifndef LIBPAX
+#if !(LIBPAX)   
 uint8_t volatile channel = WIFI_CHANNEL_MIN;   // channel rotation counter
 #endif
 uint8_t volatile rf_load = 0;                  // RF traffic indicator
-#ifndef LIBPAX
+#if !(LIBPAX)   
 uint16_t volatile macs_wifi = 0, macs_ble = 0; // globals for display
 #endif
 
@@ -304,35 +304,31 @@ void setup() {
   if (RTC_runmode == RUNMODE_MAINTENANCE)
     start_boot_menu();
 
-#ifndef LIBPAX
+#if !(LIBPAX)   
   // start mac processing task
   ESP_LOGI(TAG, "Starting MAC processor...");
   macQueueInit();
 #else
-ESP_LOGI(TAG, "Starting libpax...");
+  ESP_LOGI(TAG, "Starting libpax...");
 #if (defined WIFICOUNTER || defined BLECOUNTER) 
   struct libpax_config_t configuration;
   libpax_default_config(&configuration);
   ESP_LOGI(TAG, "BLESCAN: %d", cfg.blescan);
   ESP_LOGI(TAG, "WIFISCAN: %d", cfg.wifiscan);
-  if(!(cfg.blescan && cfg.wifiscan)) {
-    configuration.wificounter = cfg.wifiscan;
-    configuration.blecounter = cfg.blescan;
+  configuration.wificounter = cfg.wifiscan;
+  configuration.blecounter = cfg.blescan;
 
-    configuration.wifi_channel_map = WIFI_CHANNEL_ALL;
-    configuration.wifi_channel_switch_interval = cfg.wifichancycle;
-    configuration.wifi_rssi_threshold = cfg.rssilimit;
+  configuration.wifi_channel_map = WIFI_CHANNEL_ALL;
+  configuration.wifi_channel_switch_interval = cfg.wifichancycle;
+  configuration.wifi_rssi_threshold = cfg.rssilimit;
 
-    configuration.blescantime = cfg.blescantime;
+  configuration.blescantime = cfg.blescantime;
 
-    int config_update = libpax_update_config(&configuration);
-    if(config_update != 0) {
-      ESP_LOGE(TAG, "Error in libpax configuration.");
-    } else {
-      init_libpax();
-    }
+  int config_update = libpax_update_config(&configuration);
+  if(config_update != 0) {
+    ESP_LOGE(TAG, "Error in libpax configuration.");
   } else {
-    ESP_LOGE(TAG, "Error in libpax configuration: Wifi and BLE are not supported at the same time!");
+    init_libpax();
   }
 #endif
 #endif
@@ -345,7 +341,7 @@ ESP_LOGI(TAG, "Starting libpax...");
 // or remove bluetooth stack from RAM, if option bluetooth is not compiled
 #if (BLECOUNTER)
   strcat_P(features, " BLE");
-#ifndef LIBPAX
+#if !(LIBPAX)   
   if (cfg.blescan) {
     ESP_LOGI(TAG, "Starting Bluetooth...");
     start_BLEscan();
@@ -354,12 +350,13 @@ ESP_LOGI(TAG, "Starting libpax...");
 #endif
 #else
   // remove bluetooth stack to gain more free memory
-#ifndef LIBPAX
+#if !(LIBPAX)   
   btStop();
-#endif
   esp_bt_mem_release(ESP_BT_MODE_BTDM);
   esp_coex_preference_set(
       ESP_COEX_PREFER_WIFI); // configure Wifi/BT coexist lib
+#endif
+
 #endif
 
 // initialize gps
@@ -466,7 +463,7 @@ ESP_LOGI(TAG, "Starting libpax...");
 
 #if (WIFICOUNTER)
   strcat_P(features, " WIFI");
-#ifndef LIBPAX
+#if !(LIBPAX)   
   // install wifi driver in RAM and start channel hopping
   wifi_sniffer_init();
   // start wifi sniffing, if enabled
@@ -485,7 +482,7 @@ ESP_LOGI(TAG, "Starting libpax...");
   // initialize salt value using esp_random() called by random() in
   // arduino-esp32 core. Note: do this *after* wifi has started, since
   // function gets it's seed from RF noise
-#ifndef LIBPAX
+#if !(LIBPAX)   
   reset_counters();
 #endif
 

--- a/src/ota.cpp
+++ b/src/ota.cpp
@@ -150,7 +150,6 @@ int do_ota_update() {
 
   WiFiClientSecure client;
 
-  client.setCACert(bintray.getCertificate(currentHost));
   client.setTimeout(RESPONSE_TIMEOUT_MS);
 
   if (!client.connect(currentHost.c_str(), port)) {
@@ -162,7 +161,6 @@ int do_ota_update() {
   while (redirect) {
     if (currentHost != prevHost) {
       client.stop();
-      client.setCACert(bintray.getCertificate(currentHost));
       if (!client.connect(currentHost.c_str(), port)) {
         ESP_LOGI(TAG, "Redirect detected, but cannot connect to %s",
                  currentHost.c_str());

--- a/src/paxcounter_orig.conf
+++ b/src/paxcounter_orig.conf
@@ -30,7 +30,7 @@
 #define BLESCANINTERVAL                 80      // [illiseconds] scan interval, see below, 3 .. 10240, default 80ms = 100% duty cycle
 
 // Use libpax instead of default counting algorithms
-#define LIBPAX                          1    
+#define LIBPAX                          0
 
 // Corona Exposure Notification Service(ENS) counter
 #define COUNT_ENS                       1       // count found number of devices which advertise Exposure Notification Service

--- a/src/paxcounter_orig.conf
+++ b/src/paxcounter_orig.conf
@@ -20,7 +20,7 @@
 
 // MAC sniffing parameters
 #define MACFILTER                       1       // set to 0 if you want to scan all devices, 1 to scan only devices with random MACs (aka smartphones) [default = 1]
-#define BLECOUNTER                      1       // set to 0 if you do not want to install the BLE sniffer
+#define BLECOUNTER                      0       // set to 0 if you do not want to install the BLE sniffer
 #define WIFICOUNTER                     1       // set to 0 if you do not want to install the WIFI sniffer
 #define MAC_QUEUE_SIZE                  50      // size of MAC processing buffer (number of MACs) [default = 50]
 
@@ -28,6 +28,9 @@
 #define BLESCANTIME                     0       // [seconds] scan duration, 0 means infinite [default], see note below
 #define BLESCANWINDOW                   80      // [milliseconds] scan window, see below, 3 .. 10240, default 80ms
 #define BLESCANINTERVAL                 80      // [illiseconds] scan interval, see below, 3 .. 10240, default 80ms = 100% duty cycle
+
+// Use libpax instead of default counting algorithms
+#define LIBPAX                          1    
 
 // Corona Exposure Notification Service(ENS) counter
 #define COUNT_ENS                       1       // count found number of devices which advertise Exposure Notification Service

--- a/src/rcommand.cpp
+++ b/src/rcommand.cpp
@@ -72,6 +72,7 @@ void set_sleepcycle(uint8_t val[]) {
 
 void set_wifichancycle(uint8_t val[]) {
   cfg.wifichancycle = val[0];
+  #ifndef LIBAPX
   // update Wifi channel rotation timer period
   if (cfg.wifichancycle > 0) {
     if (xTimerIsTimerActive(WifiChanTimer) == pdFALSE)
@@ -88,10 +89,14 @@ void set_wifichancycle(uint8_t val[]) {
     channel = WIFI_CHANNEL_MIN;
     ESP_LOGI(TAG, "Remote command: set Wifi channel hopping to off");
   }
+  #else
+  // TODO update libpax configuration
+  #endif
 }
 
 void set_blescantime(uint8_t val[]) {
   cfg.blescantime = val[0];
+  #ifndef LIBPAX
   ESP_LOGI(TAG, "Remote command: set BLE scan time to %.1f seconds",
            cfg.blescantime / float(100));
   // stop & restart BLE scan task to apply new parameter
@@ -99,6 +104,9 @@ void set_blescantime(uint8_t val[]) {
     stop_BLEscan();
     start_BLEscan();
   }
+  #else
+    // TODO update libpax configuration
+  #endif
 }
 
 void set_countmode(uint8_t val[]) {
@@ -240,20 +248,28 @@ void set_loraadr(uint8_t val[]) {
 
 void set_blescan(uint8_t val[]) {
   ESP_LOGI(TAG, "Remote command: set BLE scanner to %s", val[0] ? "on" : "off");
+  #ifndef LIBPAX
   macs_ble = 0; // clear BLE counter
   cfg.blescan = val[0] ? 1 : 0;
   if (cfg.blescan)
     start_BLEscan();
   else
     stop_BLEscan();
+  #else
+  // TODO update libpax configuration
+  #endif 
 }
 
 void set_wifiscan(uint8_t val[]) {
   ESP_LOGI(TAG, "Remote command: set WIFI scanner to %s",
            val[0] ? "on" : "off");
+  #ifndef LIBPAX
   macs_wifi = 0; // clear WIFI counter
   cfg.wifiscan = val[0] ? 1 : 0;
   switch_wifi_sniffer(cfg.wifiscan);
+  #else
+  // TODO update libpax configuration
+  #endif 
 }
 
 void set_wifiant(uint8_t val[]) {

--- a/src/rcommand.cpp
+++ b/src/rcommand.cpp
@@ -97,7 +97,7 @@ void set_wifichancycle(uint8_t val[]) {
 
 void set_blescantime(uint8_t val[]) {
   cfg.blescantime = val[0];
-  #ifndef LIBPAX
+  #if !(LIBPAX)   
   ESP_LOGI(TAG, "Remote command: set BLE scan time to %.1f seconds",
            cfg.blescantime / float(100));
   // stop & restart BLE scan task to apply new parameter
@@ -250,24 +250,19 @@ void set_loraadr(uint8_t val[]) {
 void set_blescan(uint8_t val[]) {
   ESP_LOGI(TAG, "Remote command: set BLE scanner to %s", val[0] ? "on" : "off");
   cfg.blescan = val[0] ? 1 : 0;
-  #ifndef LIBPAX
+  #if !(LIBPAX)   
   macs_ble = 0; // clear BLE counter
   if (cfg.blescan)
     start_BLEscan();
   else
     stop_BLEscan();
   #else
-  if(cfg.blescan) {
-    cfg.wifiscan = 0;
-    // Restart of libpax while switching scannings does not work atm
-    // libpax_counter_stop();
-    // libpax_config_t current_config;
-    // libpax_get_current_config(&current_config);
-    // current_config.wificounter = 0;
-    // current_config.blecounter = 1;
-    // libpax_update_config(&current_config);
-    // init_libpax();
-  }
+  libpax_counter_stop();
+  libpax_config_t current_config;
+  libpax_get_current_config(&current_config);
+  current_config.blecounter = cfg.blescan;
+  libpax_update_config(&current_config);
+  init_libpax();
   #endif 
 }
 
@@ -275,21 +270,16 @@ void set_wifiscan(uint8_t val[]) {
   ESP_LOGI(TAG, "Remote command: set WIFI scanner to %s",
            val[0] ? "on" : "off");
   cfg.wifiscan = val[0] ? 1 : 0;
-  #ifndef LIBPAX
+  #if !(LIBPAX)   
   macs_wifi = 0; // clear WIFI counter
   switch_wifi_sniffer(cfg.wifiscan);
   #else
-  if(cfg.wifiscan) {
-    cfg.blescan = 0;
-    // Restart of libpax while switching scannings does not work atm
-    // libpax_counter_stop();
-    // libpax_config_t current_config;
-    // libpax_get_current_config(&current_config);
-    // current_config.wificounter = 1;
-    // current_config.blecounter = 0;
-    // libpax_update_config(&current_config);
-    // init_libpax();
-  }
+  libpax_counter_stop();
+  libpax_config_t current_config;
+  libpax_get_current_config(&current_config);
+  current_config.wificounter = cfg.wifiscan;
+  libpax_update_config(&current_config);
+  init_libpax();
   #endif 
 }
 

--- a/src/rcommand.cpp
+++ b/src/rcommand.cpp
@@ -1,6 +1,7 @@
 // Basic Config
 #include "globals.h"
 #include "rcommand.h"
+#include "libpax_helpers.h"
 
 // Local logging tag
 static const char TAG[] = __FILE__;
@@ -248,27 +249,47 @@ void set_loraadr(uint8_t val[]) {
 
 void set_blescan(uint8_t val[]) {
   ESP_LOGI(TAG, "Remote command: set BLE scanner to %s", val[0] ? "on" : "off");
+  cfg.blescan = val[0] ? 1 : 0;
   #ifndef LIBPAX
   macs_ble = 0; // clear BLE counter
-  cfg.blescan = val[0] ? 1 : 0;
   if (cfg.blescan)
     start_BLEscan();
   else
     stop_BLEscan();
   #else
-  // TODO update libpax configuration
+  if(cfg.blescan) {
+    cfg.wifiscan = 0;
+    // Restart of libpax while switching scannings does not work atm
+    // libpax_counter_stop();
+    // libpax_config_t current_config;
+    // libpax_get_current_config(&current_config);
+    // current_config.wificounter = 0;
+    // current_config.blecounter = 1;
+    // libpax_update_config(&current_config);
+    // init_libpax();
+  }
   #endif 
 }
 
 void set_wifiscan(uint8_t val[]) {
   ESP_LOGI(TAG, "Remote command: set WIFI scanner to %s",
            val[0] ? "on" : "off");
+  cfg.wifiscan = val[0] ? 1 : 0;
   #ifndef LIBPAX
   macs_wifi = 0; // clear WIFI counter
-  cfg.wifiscan = val[0] ? 1 : 0;
   switch_wifi_sniffer(cfg.wifiscan);
   #else
-  // TODO update libpax configuration
+  if(cfg.wifiscan) {
+    cfg.blescan = 0;
+    // Restart of libpax while switching scannings does not work atm
+    // libpax_counter_stop();
+    // libpax_config_t current_config;
+    // libpax_get_current_config(&current_config);
+    // current_config.wificounter = 1;
+    // current_config.blecounter = 0;
+    // libpax_update_config(&current_config);
+    // init_libpax();
+  }
   #endif 
 }
 

--- a/src/reset.cpp
+++ b/src/reset.cpp
@@ -107,12 +107,14 @@ void enter_deepsleep(const uint64_t wakeup_sec, gpio_num_t wakeup_gpio) {
   sendTimer.detach();
 
   // switch off radio and other power consuming hardware
+#ifndef LIBPAX
 #if (WIFICOUNTER)
   switch_wifi_sniffer(0);
 #endif
 #if (BLECOUNTER)
   stop_BLEscan();
   btStop();
+#endif
 #endif
 #if (HAS_SDS011)
   sds011_sleep(void);

--- a/src/reset.cpp
+++ b/src/reset.cpp
@@ -107,7 +107,7 @@ void enter_deepsleep(const uint64_t wakeup_sec, gpio_num_t wakeup_gpio) {
   sendTimer.detach();
 
   // switch off radio and other power consuming hardware
-#ifndef LIBPAX
+#if !(LIBPAX)   
 #if (WIFICOUNTER)
   switch_wifi_sniffer(0);
 #endif

--- a/src/senddata.cpp
+++ b/src/senddata.cpp
@@ -57,7 +57,11 @@ void SendPayload(uint8_t port) {
 // write data to sdcard, if present
 #if (HAS_SDCARD)
   if (port == COUNTERPORT) {
+#ifndef LIBPAX
     sdcardWriteData(macs_wifi, macs_ble
+#else
+    sdcardWriteData(libpax_macs_wifi, libpax_macs_ble
+#endif
 #if (COUNT_ENS)
                     ,
                     cwa_report()
@@ -87,9 +91,20 @@ void sendData() {
     case COUNT_DATA:
       payload.reset();
 #if !(PAYLOAD_OPENSENSEBOX)
+#ifndef LIBPAX     
       payload.addCount(macs_wifi, MAC_SNIFF_WIFI);
-      if (cfg.blescan)
+#else
+      ESP_LOGI(TAG, "Sending libpax wifi count: %d", libpax_macs_wifi);
+      payload.addCount(libpax_macs_wifi, MAC_SNIFF_WIFI);
+#endif
+      if (cfg.blescan) {
+#ifndef LIBPAX
         payload.addCount(macs_ble, MAC_SNIFF_BLE);
+#else    
+        ESP_LOGI(TAG, "Sending libpax ble count: %d", libpax_macs_ble);
+        payload.addCount(libpax_macs_ble, MAC_SNIFF_BLE);
+#endif
+      }
 #endif
 #if (HAS_GPS)
       if (GPSPORT == COUNTERPORT) {
@@ -102,9 +117,19 @@ void sendData() {
       }
 #endif
 #if (PAYLOAD_OPENSENSEBOX)
+#ifndef LIBPAX     
       payload.addCount(macs_wifi, MAC_SNIFF_WIFI);
-      if (cfg.blescan)
+#else
+      ESP_LOGI(TAG, "Sending libpax wifi count: %d", libpax_macs_wifi);
+      payload.addCount(libpax_macs_wifi, MAC_SNIFF_WIFI);
+#endif
+      if (cfg.blescan) {
+#ifndef LIBPAX
         payload.addCount(macs_ble, MAC_SNIFF_BLE);
+#else    
+        ESP_LOGI(TAG, "Sending libpax ble count: %d", libpax_macs_ble);
+        payload.addCount(libpax_macs_ble, MAC_SNIFF_BLE);
+#endif
 #endif
 #if (HAS_SDS011)
       sds011_store(&sds_status);

--- a/src/senddata.cpp
+++ b/src/senddata.cpp
@@ -57,7 +57,7 @@ void SendPayload(uint8_t port) {
 // write data to sdcard, if present
 #if (HAS_SDCARD)
   if (port == COUNTERPORT) {
-#ifndef LIBPAX
+#if !(LIBPAX)   
     sdcardWriteData(macs_wifi, macs_ble
 #else
     sdcardWriteData(libpax_macs_wifi, libpax_macs_ble
@@ -91,14 +91,14 @@ void sendData() {
     case COUNT_DATA:
       payload.reset();
 #if !(PAYLOAD_OPENSENSEBOX)
-#ifndef LIBPAX     
+#if !(LIBPAX)        
       payload.addCount(macs_wifi, MAC_SNIFF_WIFI);
 #else
       ESP_LOGI(TAG, "Sending libpax wifi count: %d", libpax_macs_wifi);
       payload.addCount(libpax_macs_wifi, MAC_SNIFF_WIFI);
 #endif
       if (cfg.blescan) {
-#ifndef LIBPAX
+#if !(LIBPAX)   
         payload.addCount(macs_ble, MAC_SNIFF_BLE);
 #else    
         ESP_LOGI(TAG, "Sending libpax ble count: %d", libpax_macs_ble);
@@ -117,14 +117,14 @@ void sendData() {
       }
 #endif
 #if (PAYLOAD_OPENSENSEBOX)
-#ifndef LIBPAX     
+#if !(LIBPAX)    
       payload.addCount(macs_wifi, MAC_SNIFF_WIFI);
 #else
       ESP_LOGI(TAG, "Sending libpax wifi count: %d", libpax_macs_wifi);
       payload.addCount(libpax_macs_wifi, MAC_SNIFF_WIFI);
 #endif
       if (cfg.blescan) {
-#ifndef LIBPAX
+#if !(LIBPAX)   
         payload.addCount(macs_ble, MAC_SNIFF_BLE);
 #else    
         ESP_LOGI(TAG, "Sending libpax ble count: %d", libpax_macs_ble);

--- a/src/wifiscan.cpp
+++ b/src/wifiscan.cpp
@@ -1,4 +1,4 @@
-#ifndef LIBPAX
+#if !(LIBPAX)   
 // Basic Config
 #include "globals.h"
 #include "wifiscan.h"

--- a/src/wifiscan.cpp
+++ b/src/wifiscan.cpp
@@ -1,3 +1,4 @@
+#ifndef LIBPAX
 // Basic Config
 #include "globals.h"
 #include "wifiscan.h"
@@ -103,3 +104,4 @@ void switch_wifi_sniffer(uint8_t state) {
     esp_wifi_stop();
   }
 }
+#endif


### PR DESCRIPTION
Adds a possible use of the library [libpax](https://git.iot-uhr.de/dbsus/libpax). The project extracts the device counting code into a reusable library for further use.

Using of this feature can be toggled in the paxcounter.conf with `#define LIBPAX  1`.

Example switching of BLE and WiFi on runtime is implemented. Changing parameters used in the scanning process on runtime is not. At the moment the library is instantiated with its default configuration values, which should be the default configuration values of the paxcounter project.

The public release v0.1.1 of libpax should be available soon with which this branch will be working.