### PR TITLE
libpax version update to v.0.1.2

### DIFF
--- a/platformio_orig.ini
+++ b/platformio_orig.ini
@@ -89,7 +89,7 @@ lib_deps_basic =
     lewisxhe/AXP202X_Library @ ^1.1.3
     geeksville/esp32-micro-sdcard @ ^0.1.1
     256dpi/MQTT @ ^2.4.7
-    https://github.com/dbSuS/libpax#v0.1.1
+    https://github.com/dbSuS/libpax#v0.1.2
 lib_deps_all =
     ${common.lib_deps_basic}
     ${common.lib_deps_lora}

--- a/src/paxcounter_orig.conf
+++ b/src/paxcounter_orig.conf
@@ -20,7 +20,7 @@
 
 // MAC sniffing parameters
 #define MACFILTER                       1       // set to 0 if you want to scan all devices, 1 to scan only devices with random MACs (aka smartphones) [default = 1]
-#define BLECOUNTER                      0       // set to 0 if you do not want to install the BLE sniffer
+#define BLECOUNTER                      1       // set to 0 if you do not want to install the BLE sniffer
 #define WIFICOUNTER                     1       // set to 0 if you do not want to install the WIFI sniffer
 #define MAC_QUEUE_SIZE                  50      // size of MAC processing buffer (number of MACs) [default = 50]
 
@@ -30,7 +30,7 @@
 #define BLESCANINTERVAL                 80      // [illiseconds] scan interval, see below, 3 .. 10240, default 80ms = 100% duty cycle
 
 // Use libpax instead of default counting algorithms
-#define LIBPAX                          0
+#define LIBPAX                          0       // set to 1 to enable libpax 
 
 // Corona Exposure Notification Service(ENS) counter
 #define COUNT_ENS                       1       // count found number of devices which advertise Exposure Notification Service


### PR DESCRIPTION
libpax does not support ENS counting. But enabling it made the project not compile. This is fixed in a new release.

Also we fixed the not working default configuration in `src/paxcounter_orig.conf` as mentioned in https://github.com/cyberman54/ESP32-Paxcounter/pull/765#discussion_r599072015