### PR TITLE
Add software serial and HAL file for ESPGateway

### DIFF
--- a/include/senddata.h
+++ b/include/senddata.h
@@ -9,6 +9,7 @@
 #include "lorawan.h"
 #include "display.h"
 #include "sdcard.h"
+#include "softserial.h"
 
 #if (COUNT_ENS)
 #include "corona.h"

--- a/include/softserial.h
+++ b/include/softserial.h
@@ -1,0 +1,11 @@
+#ifndef _SOFTSERIAL_H
+#define _SOFTSERIAL_H
+
+#include <globals.h>
+#include <stdio.h>
+#include <SPI.h>
+
+bool serial_init(void);
+void serialWriteData(uint16_t, uint16_t, uint16_t = 0);
+
+#endif // _SOFTSERIAL_H

--- a/src/hal/espgateway.h
+++ b/src/hal/espgateway.h
@@ -1,0 +1,35 @@
+// clang-format off
+// upload_speed 115200
+// board esp32dev
+// display_library lib_deps_oled_display
+
+#ifndef _ESPGATEWAY_H
+#define _ESPGATEWAY_H
+
+#include <stdint.h>
+
+// Hardware related definitions for the ThingPulse ESPGateway.
+// The ESPGateway is a device with two ESP32 WROVER boards and
+// each one of them can be programmed separately
+// Read more about the device here:
+// https://thingpulse.com/new-product-the-espgateway-design/
+// https://thingpulse.com/the-espgateway-applications/
+//
+// The other ESP32 module should be flashed with
+// https://github.com/squix78/ESP32-Paxcounter-ESPGateway
+
+
+//#define CFG_sx1276_radio 0 // select LoRa chip
+#define BOARD_HAS_PSRAM // use if board has external PSRAM
+#define DISABLE_BROWNOUT 1 // comment out if you want to keep brownout feature
+
+#define HAS_LED NOT_A_PIN // on board  LED
+#define RGB_LED_COUNT 2
+#define HAS_RGB_LED SmartLed rgb_led(LED_WS2812B, RGB_LED_COUNT, GPIO_NUM_32, 0) // WS2812B RGB LED on GPIO32
+
+#define HAS_SERIAL 1
+#define SERIAL_RXD 14
+#define SERIAL_TXD 15
+#define BAUDRATE 9600
+
+#endif // end ESPGATEWAY_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -383,6 +383,11 @@ void setup() {
     strcat_P(features, " SD");
 #endif
 
+#if (HAS_SERIAL)
+  if (serial_init())
+    strcat_P(features, " SER");
+#endif
+
 #if (HAS_SDS011)
   ESP_LOGI(TAG, "init fine-dust-sensor");
   if (sds011_init())

--- a/src/senddata.cpp
+++ b/src/senddata.cpp
@@ -77,6 +77,17 @@ void SendPayload(uint8_t port) {
   }
 #endif
 
+#if (HAS_SERIAL)
+  if (port == COUNTERPORT) {
+    serialWriteData(libpax_macs_wifi, libpax_macs_ble
+#if (COUNT_ENS)
+                    ,
+                    cwa_report()
+#endif
+    );
+  }
+#endif
+
 } // SendPayload
 
 // interrupt triggered function to prepare payload to send

--- a/src/softserial.cpp
+++ b/src/softserial.cpp
@@ -1,0 +1,37 @@
+// routines for writing data to a second serial port, if present
+
+// Local logging tag
+static const char TAG[] = __FILE__;
+
+#include "softserial.h"
+
+#ifdef HAS_SERIAL
+
+
+
+bool serial_init() {
+  ESP_LOGI(TAG, "Initializing Soft Serial...");
+  Serial2.begin(BAUDRATE, SERIAL_8N1, SERIAL_RXD, SERIAL_TXD);
+  return true;
+}
+
+void serialWriteData(uint16_t noWifi, uint16_t noBle, __attribute__((unused)) uint16_t noBleCWA) {
+#if (HAS_SDS011)
+  sdsStatus_t sds;
+#endif
+  ESP_LOGD(TAG, "writing to software serial port");
+  Serial2.printf("{\"wifi\": %d, \"ble\": %d ", noWifi, noBle);
+#if (COUNT_ENS)
+  Serial2.printf(", \"bleCWA\": %d", noBleCWA);
+#endif
+#if (HAS_SDS011)
+  sds011_store(&sds);
+  Serial2.printf(", \"pm10\": %5.1f, \"pm10\": %4.1f", sds.pm10, sds.pm25);
+#endif
+  Serial2.println("}");
+
+
+}
+
+
+#endif // (HAS_SERIAL)


### PR DESCRIPTION
This PR adds the ability to send the collected data over a software serial connection to another device. In addition, this PR also adds a HAL file for the ESPGateway which contains two ESP32-WROVER boards and external WiFi antennas. The first ESP32 will run this project to collect the data. It then sends it over serial lines to the second ESP32 which is connected over WiFi to a MQTT server.
In concept it is very similar to the already implemented MQTT-over-Ethernet setup, except that a second ESP32 is used for the WiFi uplink.

The second ESP32 will have to be flashed with this project here:
https://github.com/squix78/ESP32-Paxcounter-ESPGateway

I wasn't sure how and if I should add that simple code in this PR as well or if it was better to keep it separate from this project. My code currently creates a JSON string with the WiFi and BLE counters and sends this JSON string to the second "uplink" ESP32. This was very convenient since the JSON string can just be wrapped and forwarded to the MQTT broker. If you would prefer a more generic protocol for the serial line please let me know and I will adopt it. 

Motivation
The ESPGateway hardware seems like the perfect fit for this project: the external antennas extend the reach of the statistics collection to cover e.g. a bigger event or open space with less devices. The two ESP32 allow for independent uplink while still counting WiFi and BLE devices. In order to simplify the setup with would be great if you could accept this PR. BTW: kudos for the clean design of this project. It was very easy to add support for another device and communication protocol!