### PR TITLE
Added manual for the things stack community edition and ttn mapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,22 @@ Format of the data is CSV, which can easily imported into LibreOffice, Excel, ..
 
 If you want to change this please look into src/sdcard.cpp and include/sdcard.h.
 
+# Integration into "The Things Stack Community Edition" aka "The Things Stack V3"
+
+To use the ESP32-Paxcounter in The Things Stack Community Edition you need an account to reach the console. Go to:
+- [The Things Stack Community Edition Console](https://console.cloud.thethings.network/)
+- choose your region and go to applications
+- create an application by clicking "**+ Add application**" and give it a id, name, etc.
+- create a device by clicking "**+ Add end device**"
+- Select the end device:  choose the Brand "**Open Source Community Projects**" and the Model "**ESP32-Paxcounter**", leave Hardware Version to "**Unknown**" and select your **Firmware Version** and **Profile (Region)**
+- Enter registration data: choose the **frequency plan** (for EU choose the recommended), set the **AppEUI** (Fill with zeros), set the **DeviceEUI** (generate), set the **AppKey** (generate), choose a **device ID** and hit "Register end device"
+- got to Applications -> "your App ID" -> Payload formatters -> Uplink, choose "**Repository**" and hit "Save changes"
+
+The "Repository" payload decoder uses the packed format, explained below. If you want to use MyDevices from Cayenne you should use the Cayenne payload decoder instead.
+
+# TTN Mapper
+
+If you want your devices to be feeding the [TTN Mapper](https://ttnmapper.org/), just follow this manual: https://docs.ttnmapper.org/integration/tts-integration-v3.html - different than indicated in the manual you can leave the payload decoder to "Repository" for the ESP32-Paxcounter and you are fine.
 
 # Payload format
 
@@ -274,11 +290,15 @@ You can select different payload formats in `paxcounter.conf`:
 
 - [***CayenneLPP***](https://mydevices.com/cayenne/docs/lora/#lora-cayenne-low-power-payload-reference-implementation) generates MyDevices Cayenne readable fields
 
+**Decrepated information from the things network v2 >>**
+
 If you're using [TheThingsNetwork](https://www.thethingsnetwork.org/) (TTN) you may want to use a payload converter. Go to TTN Console - Application - Payload Formats and paste the code example below in tabs Decoder and Converter. This way your MQTT application can parse the fields `pax`, `ble` and `wifi`.
 
 To add your device to myDevices Cayenne platform select "Cayenne-LPP" from Lora device list and use the CayenneLPP payload encoder. 
 
 To track a paxcounter device with on board GPS and at the same time contribute to TTN coverage mapping, you simply activate the [TTNmapper integration](https://www.thethingsnetwork.org/docs/applications/ttnmapper/) in TTN Console. Both formats *plain* and *packed* generate the fields `latitude`, `longitude` and `hdop` required by ttnmapper. Important: set TTN mapper port filter to '4' (paxcounter GPS Port).
+
+**<< Decrepated information from the things network v2**
 
 Hereafter described is the default *plain* format, which uses MSB bit numbering. Under /TTN in this repository you find some ready-to-go decoders which you may copy to your TTN console:
 


### PR DESCRIPTION
Added the description how to use the ESP32-Paxcounter in The Things Stack Community Edition, with the new integration into the lorawan device repo (follow up to [https://github.com/cyberman54/ESP32-Paxcounter/pull/819](https://github.com/cyberman54/ESP32-Paxcounter/pull/819)). Now you can choose the ESP32-Paxcounter and do not use the manual mode. And added a short description with link to the new stack v3 ttn mapper integration as well, because now its handled by a webhook and no integration. Marked the part which described the integration into the v2 console as "Decrepated" - maybe it can be removed?