### PR TITLE
ttgo LoRa32 v1 does not have an SD card, and enabling it prevents the LoRa radio from working

### DIFF
--- a/src/hal/ttgov1.h
+++ b/src/hal/ttgov1.h
@@ -19,7 +19,7 @@
 #define HAS_BUTTON KEY_BUILTIN
 
 // enable only if you want to store a local paxcount table on the device
-#define HAS_SDCARD  1      // this board has an SD-card-reader/writer
+// #define HAS_SDCARD  1      // this board has an SD-card-reader/writer
 // Pins for SD-card
 #define SDCARD_CS    (13)
 #define SDCARD_MOSI  (15)


### PR DESCRIPTION
As title.

The symptoms, prior to this patch, are exactly as described by @DierkJ in https://github.com/cyberman54/ESP32-Paxcounter/issues/577 - specifically the ASSERT at radio.c line 801 fails.

The solution was lifted from the @DierkJ fork (thanks!) after I realised he had the same hardware as me, and disabling HAS_SDCARD was all that was needed to get the device transmitting and linked to TheThingsNetwork.

The photo of my board is identical to the one in that issue - @cyberman54 you stated

> This is not the "original" TTGO T1, looks like a fake Heltec board.

but I believe it is an original "TTGO LoRa32 v1" as it matches the photographs at https://www.thethingsnetwork.org/forum/t/big-esp32-sx127x-topic-part-3/18436 and http://www.lilygo.cn/prod_view.aspx?TypeId=50060&Id=1134&FId=t3:50060:3 exactly. And there's no SD card.