### PR TITLE
Adding NTP time synchronization on startup

### DIFF
--- a/include/main.h
+++ b/include/main.h
@@ -23,5 +23,6 @@
 #include "libpax_helpers.h"
 #include "power.h"
 #include "antenna.h"
+#include "ntp.h"
 
 #endif

--- a/include/ntp.h
+++ b/include/ntp.h
@@ -1,0 +1,10 @@
+#ifndef NTP_H
+#define NTP_H
+
+#include "globals.h"
+
+#include <WiFi.h>
+
+void set_network_time();
+
+#endif // NTP_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -278,6 +278,10 @@ void setup() {
     start_ota_update();
 #endif
 
+#if (TIME_SYNC_NTP)
+  set_network_time();
+#endif
+
 #if (BOOTMENU)
   // start local webserver after each coldstart
   if (RTC_runmode == RUNMODE_POWERCYCLE)

--- a/src/ntp.cpp
+++ b/src/ntp.cpp
@@ -1,0 +1,64 @@
+/*
+ Parts of this code:
+ Copyright (c) 2014-present PlatformIO <contact@platformio.org>
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+#include "ntp.h"
+
+const char* ntpServer = "pool.ntp.org";
+
+
+void set_network_time() {
+  const char *host = clientId;
+
+  ESP_LOGI(TAG, "Starting Wifi for time synchronization");
+
+  WiFi.disconnect(true);
+  WiFi.config(INADDR_NONE, INADDR_NONE,
+              INADDR_NONE); // call is only a workaround for bug in WiFi class
+  // see https://github.com/espressif/arduino-esp32/issues/806
+  WiFi.setHostname(host);
+  WiFi.mode(WIFI_STA);
+  WiFi.begin();
+  // 1st try
+  WiFi.begin(WIFI_SSID, WIFI_PASS);
+  while (WiFi.status() == WL_DISCONNECTED) {
+    delay(500);
+  }
+  // 2nd try
+  if (WiFi.status() != WL_CONNECTED) {
+    WiFi.begin(WIFI_SSID, WIFI_PASS);
+    delay(500);
+  }
+
+  if (WiFi.status() == WL_CONNECTED) {
+    // we now have wifi connection and try to do an time_sync over wifi update
+    ESP_LOGI(TAG, "Connected to %s", WIFI_SSID);
+
+    // set time server while you are connected to wife
+    long current_time = 0L;
+    unsigned long measured_at = 0L;
+    
+    if(queryNTP(ntpServer, current_time, measured_at)){
+      setTime(current_time);
+      ESP_LOGI(TAG, "Set local date time to %s", dateTime().c_str());
+    } else{
+      ESP_LOGI(TAG, "Could not connect to ntp server %s", ntpServer);  
+    }
+  } else {
+    // wifi did not connect
+    ESP_LOGI(TAG, "Could not connect to %s", WIFI_SSID);
+  }
+}

--- a/src/paxcounter_orig.conf
+++ b/src/paxcounter_orig.conf
@@ -80,6 +80,7 @@
 #define RESPONSE_TIMEOUT_MS             60000   // firmware binary server connection timeout [milliseconds]
 
 // settings for syncing time of node with a time source (network / gps / rtc / timeserver)
+#define TIME_SYNC_NTP                   0       // set to 1 to use OTA_WIFI_SSID to call NTP server on startup, 0 means off [default = 0]
 #define TIME_SYNC_LORAWAN               1       // set to 1 to use LORA network as time source, 0 means off [default = 1]
 #define TIME_SYNC_LORASERVER            0       // set to 1 to use LORA timeserver as time source, 0 means off [default = 0]
 #define TIME_SYNC_INTERVAL              60      // sync time attempt each .. minutes from time source [default = 60], 0 means off


### PR DESCRIPTION
I was looking for a way to set the correct time without owning a RTC. Browsing the code I found the ezTime provides a handy solution, so I integrated it. Not sure if reusing the OTA wifi settings is the best way, but I'm open to suggestions. 