### PR TITLE
fix typo 'bei' [GER] to 'by' [ENG] in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Edit `platformio_orig.ini` and select desired hardware target in section boards.
 ## paxcounter.conf
 Edit `src/paxcounter_orig.conf` and tailor settings in this file according to your needs and use case. Please take care of the duty cycle regulations of the LoRaWAN network you're going to use. Copy or rename to `src/paxcounter.conf`.
 
-If your device has a **real time clock** it can be updated bei either LoRaWAN network or GPS time, according to settings *TIME_SYNC_INTERVAL* and *TIME_SYNC_LORAWAN* in `paxcounter.conf`.
+If your device has a **real time clock** it can be updated by either LoRaWAN network or GPS time, according to settings *TIME_SYNC_INTERVAL* and *TIME_SYNC_LORAWAN* in `paxcounter.conf`.
 
 ## src/lmic_config.h
 Edit `src/lmic_config.h` and tailor settings in this file according to your country and device hardware. Please take care of national regulations when selecting the frequency band for LoRaWAN.


### PR DESCRIPTION
As a German, I know this word, but do our English-speaking m8s?