### PR TITLE
Build workflow for S3-usb-stick boards

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
           #   platformio-path: ~\AppData\Local\platformio\Cache
         board:
           [
+            generic.h,
             ebox.h,
             eboxtube.h,
             ecopower.h,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,8 +129,8 @@ jobs:
           cp src/ota_sample.conf src/ota.conf
           cp src/paxcounter_orig.conf src/paxcounter.conf
       - name: Clean
-        run: pio run -t clean -e usb
+        run: pio run -t clean -e ci
       - name: Run PlatformIO CI for ${{ matrix.board }}
         env:
           CI_HALFILE: ${{ matrix.board }}
-        run: pio run -e usb
+        run: pio run -e ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,17 +14,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        # os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - os: ubuntu-latest
             path: ~/.cache/pip
             platformio-path: ~/.platformio
-          # - os: macos-latest
-          #   path: ~/Library/Caches/pip
-          #   platformio-path: ~/Library/Caches/platformio
-          # - os: windows-latest
-          #   path: ~\AppData\Local\pip\Cache
-          #   platformio-path: ~\AppData\Local\platformio\Cache
         board:
           [
             generic.h,
@@ -94,3 +87,50 @@ jobs:
         env:
           CI_HALFILE: ${{ matrix.board }}
         run: pio run -e ci
+
+  build-s3-usb-stick:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        include:
+          - os: ubuntu-latest
+            path: ~/.cache/pip
+            platformio-path: ~/.platformio
+        board: [ttgotdongles3.h, ttgotdongledisplays3.h]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ${{ matrix.path }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Cache PlatformIO
+        uses: actions/cache@v3
+        with:
+          path: ${{ matrix.platformio-path }}
+          key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9.13"
+      - name: Install PlatformIO
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade platformio
+      - name: Copy of necessary files
+        run: |
+          cp platformio_orig_s3-usb-stick.ini platformio.ini
+          cp src/loraconf_sample.h src/loraconf.h
+          cp src/ota_sample.conf src/ota.conf
+          cp src/paxcounter_orig.conf src/paxcounter.conf
+      - name: Clean
+        run: pio run -t clean -e usb
+      - name: Run PlatformIO CI for ${{ matrix.board }}
+        env:
+          CI_HALFILE: ${{ matrix.board }}
+        run: pio run -e usb

--- a/platformio_orig_s3-usb-stick.ini
+++ b/platformio_orig_s3-usb-stick.ini
@@ -31,7 +31,6 @@ lib_deps_all =
     spacehuhn/SimpleButton
     256dpi/MQTT @ ^2.5.0
 build_flags_basic =
-    -include "src/hal/${board.halfile}"
     -include "src/paxcounter.conf"
     '-DCORE_DEBUG_LEVEL=${common.debug_level}'
     '-DLOG_LOCAL_LEVEL=${common.debug_level}'
@@ -52,11 +51,19 @@ upload_speed = ${common.upload_speed}
 ;upload_port = COM6
 platform = ${common.platform_espressif32}
 lib_deps = ${common.lib_deps_all}
-build_flags = ${common.build_flags_all}
+build_flags =
+   -include "src/hal/${board.halfile}"
+   ${common.build_flags_all}
 upload_protocol = ${common.upload_protocol}
 extra_scripts = ${common.extra_scripts}
 monitor_speed = ${common.monitor_speed}
 monitor_filters = time, esp32_exception_decoder, default
 
 [env:usb]
+upload_protocol = esptool
+
+[env:ci]
+build_flags =
+    -include "src/hal/${sysenv.CI_HALFILE}" ; set by CI
+    ${common.build_flags_all}
 upload_protocol = esptool

--- a/platformio_orig_s3-usb-stick.ini
+++ b/platformio_orig_s3-usb-stick.ini
@@ -30,6 +30,7 @@ lib_deps_all =
     bblanchon/ArduinoJson @ ^6
     spacehuhn/SimpleButton
     256dpi/MQTT @ ^2.5.0
+    ricmoo/QRCode @ ^0.0.1
 build_flags_basic =
     -include "src/paxcounter.conf"
     '-DCORE_DEBUG_LEVEL=${common.debug_level}'

--- a/platformio_orig_s3-usb-stick.ini
+++ b/platformio_orig_s3-usb-stick.ini
@@ -44,7 +44,7 @@ build_flags_all =
 
 [env]
 framework = arduino
-board = ESP32-S3-DevKitC-1
+board = esp32-s3-devkitc-1
 board_build.partitions = min_spiffs.csv
 build_type = release
 upload_speed = ${common.upload_speed}

--- a/src/hal/generic.h
+++ b/src/hal/generic.h
@@ -62,7 +62,7 @@
 
 #define CFG_sx1276_radio 1 // select LoRa chip
 //#define CFG_sx1272_radio 1 // select LoRa chip
-#define BOARD_HAS_PSRAM // use if board has external PSRAM
+//#define BOARD_HAS_PSRAM // use if board has external SPIRAM, note: this will reduce IRAM0 by 64KB for SPIRAM cache
 #define DISABLE_BROWNOUT 1 // comment out if you want to keep brownout feature
 
 #define HAS_DISPLAY 1

--- a/src/hal/m5fire.h
+++ b/src/hal/m5fire.h
@@ -31,9 +31,7 @@
 #define DISABLE_BROWNOUT 1 // comment out if you want to keep brownout feature
 
 #define HAS_LED NOT_A_PIN // no on board LED (?)
-#define RGB_LED_COUNT 10
-
-#define RGB_LED_COUNT 1 // we have 1 LED
+#define RGB_LED_COUNT 10 // M5fire has a stripe of 10 RGB Pixels
 #define HAS_RGB_LED FastLED.addLeds<SK6812, GPIO_NUM_15, GRB>(leds, RGB_LED_COUNT);
 #define HAS_BUTTON (39) // on board button A
 

--- a/src/hal/m5fire.h
+++ b/src/hal/m5fire.h
@@ -10,7 +10,7 @@
 
 #include <stdint.h>
 
-#define HAS_LORA 1 // comment out if device shall not send data via LoRa or has no M5 RA01 LoRa module
+//#define HAS_LORA 1 // comment out if device shall not send data via LoRa or has no M5 RA01 LoRa module
 #define LORA_SCK  SCK
 #define LORA_CS   SS
 #define LORA_MISO MISO
@@ -21,7 +21,7 @@
 #define LORA_IO2  LMIC_UNUSED_PIN
 
 // enable only if you want to store a local paxcount table on the device
-#define HAS_SDCARD  1      // this board has an SD-card-reader/writer
+//#define HAS_SDCARD  1      // this board has an SD-card-reader/writer
 #define SDCARD_CS    GPIO_NUM_4
 #define SDCARD_MOSI  MOSI
 #define SDCARD_MISO  MISO
@@ -32,8 +32,8 @@
 
 #define HAS_LED NOT_A_PIN // no on board LED (?)
 #define RGB_LED_COUNT 10 // M5fire has a stripe of 10 RGB Pixels
-#define HAS_RGB_LED FastLED.addLeds<SK6812, GPIO_NUM_15, GRB>(leds, RGB_LED_COUNT);
-#define HAS_BUTTON (39) // on board button A
+//#define HAS_RGB_LED FastLED.addLeds<SK6812, GPIO_NUM_15, GRB>(leds, RGB_LED_COUNT);
+//#define HAS_BUTTON (39) // on board button A
 
 // power management settings
 #define HAS_IP5306 1 // has IP5306 chip
@@ -48,7 +48,7 @@
 //#define GPS_INT GPIO_NUM_36 // 30ns accurary timepulse, to be external wired on pcb: shorten R12!
 
 // Display Settings
-#define HAS_DISPLAY 2   // TFT-LCD
+//#define HAS_DISPLAY 2   // TFT-LCD
 //#define MY_DISPLAY_FLIP  1 // use if display is rotated
 #define MY_DISPLAY_WIDTH 320
 #define MY_DISPLAY_HEIGHT 240

--- a/src/hal/m5fire.h
+++ b/src/hal/m5fire.h
@@ -1,6 +1,7 @@
 // clang-format off
 // upload_speed 921600
-// board m5stack-fire
+// board m5stack-core-esp32
+// b0ard m5stack-fire -> does not compile due to IRAM0 shortage, because 64KB of 192KB used for caching external SPIRAM
 
 // note use of GPIO16/17
 // https://www.bjoerns-techblog.de/2019/03/m5stack-fire-eine-uebersicht/
@@ -10,7 +11,7 @@
 
 #include <stdint.h>
 
-//#define HAS_LORA 1 // comment out if device shall not send data via LoRa or has no M5 RA01 LoRa module
+#define HAS_LORA 1 // comment out if device shall not send data via LoRa or has no M5 RA01 LoRa module
 #define LORA_SCK  SCK
 #define LORA_CS   SS
 #define LORA_MISO MISO
@@ -21,7 +22,7 @@
 #define LORA_IO2  LMIC_UNUSED_PIN
 
 // enable only if you want to store a local paxcount table on the device
-//#define HAS_SDCARD  1      // this board has an SD-card-reader/writer
+#define HAS_SDCARD  1      // this board has an SD-card-reader/writer
 #define SDCARD_CS    GPIO_NUM_4
 #define SDCARD_MOSI  MOSI
 #define SDCARD_MISO  MISO
@@ -32,8 +33,8 @@
 
 #define HAS_LED NOT_A_PIN // no on board LED (?)
 #define RGB_LED_COUNT 10 // M5fire has a stripe of 10 RGB Pixels
-//#define HAS_RGB_LED FastLED.addLeds<SK6812, GPIO_NUM_15, GRB>(leds, RGB_LED_COUNT);
-//#define HAS_BUTTON (39) // on board button A
+#define HAS_RGB_LED FastLED.addLeds<SK6812, GPIO_NUM_15, GRB>(leds, RGB_LED_COUNT);
+#define HAS_BUTTON (39) // on board button A
 
 // power management settings
 #define HAS_IP5306 1 // has IP5306 chip
@@ -48,7 +49,7 @@
 //#define GPS_INT GPIO_NUM_36 // 30ns accurary timepulse, to be external wired on pcb: shorten R12!
 
 // Display Settings
-//#define HAS_DISPLAY 2   // TFT-LCD
+#define HAS_DISPLAY 2   // TFT-LCD
 //#define MY_DISPLAY_FLIP  1 // use if display is rotated
 #define MY_DISPLAY_WIDTH 320
 #define MY_DISPLAY_HEIGHT 240

--- a/src/hal/ttgotdisplays3.h
+++ b/src/hal/ttgotdisplays3.h
@@ -1,6 +1,6 @@
 // clang-format off
 // upload_speed 1500000
-// board ESP32-S3-DevKitC-1
+// board esp32-s3-devkitc-1
 
 #ifndef _TTGOTDISPLAYS3_H
 #define _TTGOTDISPLAYS3_H

--- a/src/hal/ttgotdongledisplays3.h
+++ b/src/hal/ttgotdongledisplays3.h
@@ -1,6 +1,6 @@
 // clang-format off
 // upload_speed 1500000
-// board ESP32-S3-DevKitC-1
+// board esp32-s3-devkitc-1
 
 // see https://github.com/Xinyuan-LilyGO/T-Dongle-S3
 

--- a/src/hal/ttgotdongledisplays3.h
+++ b/src/hal/ttgotdongledisplays3.h
@@ -16,7 +16,7 @@
 #define SDCARD_SLOTWIDTH 4 // 4-line interface
 
 #define HAS_DISPLAY 2       // TFT-LCD
-#define TFT_TYPE DISPLAY_TDONGLE_S3
+#define TFT_TYPE DISPLAY_T_DISPLAY_S3
 #define MY_DISPLAY_FLIP  1  // use if display is rotated
 #define MY_DISPLAY_WIDTH 80
 #define MY_DISPLAY_HEIGHT 160

--- a/src/hal/ttgotdongles3.h
+++ b/src/hal/ttgotdongles3.h
@@ -1,6 +1,6 @@
 // clang-format off
 // upload_speed 1500000
-// board ESP32-S3-DevKitC-1
+// board esp32-s3-devkitc-1
 
 // for pinouts see https://github.com/Xinyuan-LilyGO/T-Dongle-S3
 


### PR DESCRIPTION
Added 

- platformio.ini and renamed it to `platformio_orig_s3-usb-stick.ini`
- build job `build-s3-usb-stick`
- updated board names for `ttgotdongles3` and `ttgotdongledisplays3` to esp32-s3-devkitc-1
- added `ricmoo/QRCode @ ^0.0.1` lib to `platformio_orig_s3-usb-stick.ini`
- changed `DISPLAY_TDONGLE_S3` to `DISPLAY_T_DISPLAY_S3` in `src/hal/ttgotdongledisplays3.h`

Workflow for `ttgotdongles3` and `ttgotdongledisplays3`  should now also run.

I do not have the actual boards to "really" test it. Maybe somebody can do that. 

The extra  `platformio_orig_s3-usb-stick.ini` should probably also be documented in the readme.