### PR TITLE
Ignore changes in docs for ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,11 +2,22 @@ name: PlatformIO CI
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'LICENSE'
+      - 'README.md'
   push:
     branches:
       - master
       - build-workflow
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'LICENSE'
+      - 'README.md'
   workflow_dispatch:
+
 
 jobs:
   build:


### PR DESCRIPTION
You can also use `[skip ci]` inside a commit message to skip the ci for small changes. 

See:
https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs
