### PR TITLE
Update heltec hal files

### DIFF
--- a/src/hal/heltec.h
+++ b/src/hal/heltec.h
@@ -8,7 +8,7 @@
 #include <stdint.h>
 
 // Hardware related definitions for Heltec V1 LoRa-32 Board
-// see https://heltec-automation-docs.readthedocs.io/en/latest/esp32/wifi_lora_32/hardware_update_log.html#v1
+// see https://docs.heltec.org/en/node/esp32/dev-board/hardware_update_log.html#v1
 
 #define HAS_LORA 1 // comment out if device shall not send data via LoRa
 #define CFG_sx1276_radio 1

--- a/src/hal/heltecv2.h
+++ b/src/hal/heltecv2.h
@@ -8,7 +8,7 @@
 #include <stdint.h>
 
 // Hardware related definitions for Heltec V2 LoRa-32 Board
-// see https://heltec-automation-docs.readthedocs.io/en/latest/esp32/wifi_lora_32/hardware_update_log.html#v2
+// see https://docs.heltec.org/en/node/esp32/dev-board/hardware_update_log.html#v2
 
 #define HAS_LORA 1       // comment out if device shall not send data via LoRa
 #define CFG_sx1276_radio 1

--- a/src/hal/heltecv21.h
+++ b/src/hal/heltecv21.h
@@ -8,7 +8,7 @@
 #include <stdint.h>
 
 // Hardware related definitions for Heltec V2.1 LoRa-32 Board
-// see https://heltec-automation-docs.readthedocs.io/en/latest/esp32/wifi_lora_32/hardware_update_log.html#v2-1
+// see https://docs.heltec.org/en/node/esp32/dev-board/hardware_update_log.html#v2-1
 
 #define HAS_LORA 1       // comment out if device shall not send data via LoRa
 #define CFG_sx1276_radio 1


### PR DESCRIPTION
I have updated the documentation links. 

But I also want to check the `BAT_VOLTAGE_DIVIDER` as discussed in #938.
At the moment it works best with `#define BAT_VOLTAGE_DIVIDER 3.2` for `heltecv2.1`. 
Also used here: http://community.heltec.cn/t/heltec-wifi-lora-v2-battery-management/147/36

I still need to check the information addressed in #938.

