### PR TITLE
Add support for BMP280 Sensor

### DIFF
--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -37,7 +37,7 @@ Depending on board hardware following features are supported:
 - Button (short press: flip display page / long press: send alarm message)
 - Battery voltage monitoring (analog read / AXP192 / IP5306)
 - GPS (Generic serial NMEA, or Quectel L76 I2C)
-- Environmental sensors (Bosch BMP180/BME280/BME680 I2C; SDS011 serial)
+- Environmental sensors (Bosch BMP180/BME280/BME680/BMP280 I2C; SDS011 serial)
 - Real Time Clock (Maxim DS3231 I2C)
 - IF482 (serial) and DCF77 (gpio) time telegram generator
 - Switch external power / battery

--- a/include/bmesensor.h
+++ b/include/bmesensor.h
@@ -16,6 +16,8 @@
 #include <Adafruit_BME280.h>
 #elif defined HAS_BMP180
 #include <Adafruit_BMP085.h>
+#elif defined HAS_BMP280
+#include <Adafruit_BMP280.h>
 #endif
 
 extern Ticker bmecycler;

--- a/platformio_orig.ini
+++ b/platformio_orig.ini
@@ -74,6 +74,7 @@ lib_deps_sensors =
     adafruit/Adafruit Unified Sensor @ ^1.1.13
     adafruit/Adafruit BME280 Library @ ^2.2.2
     adafruit/Adafruit BMP085 Library @ ^1.2.2
+    adafruit/Adafruit BMP280 Library@^2.6.8
     boschsensortec/BSEC Software Library @ 1.8.1492
     lewapek/Nova Fitness Sds dust sensors library @ ^1.5.1
 lib_deps_basic =

--- a/shared/hal/generic.h
+++ b/shared/hal/generic.h
@@ -45,8 +45,14 @@
 //#define BME280_ADDR 0x76 // change to 0x77 depending on your wiring
 
 // BMP180 sensor on I2C bus
+//#define HAS_BME 1 // Enable BME sensors in general
 //#define HAS_BMP180
 //#define BMP180_ADDR 0x77
+
+// BMP280 sensor on I2C bus
+//#define HAS_BME 1 // Enable BME sensors in general
+//#define HAS_BMP280
+//#define BMP280_ADDR 0x76
 
 // SDS011 dust sensor settings
 //#define HAS_SDS011 1 // use SDS011

--- a/src/bmesensor.cpp
+++ b/src/bmesensor.cpp
@@ -39,6 +39,10 @@ Adafruit_BME280 bme; // using I2C interface
 
 Adafruit_BMP085 bmp; // I2C
 
+#elif defined HAS_BMP280
+
+Adafruit_BMP280 bmp; // I2C
+
 #endif
 
 void setBMEIRQ() { xTaskNotify(irqHandlerTask, BME_IRQ, eSetBits); }
@@ -68,7 +72,9 @@ int bme_init(void) {
 #elif defined HAS_BMP180
   // Wire.begin(21, 22);
   rc = bmp.begin();
-
+#elif defined HAS_BMP280
+  // Wire.begin(21, 22);
+  rc = bmp.begin(BMP280_ADDR);
 #endif
 
   if (rc)
@@ -132,6 +138,12 @@ void bme_storedata(bmeStatus_t *bme_store) {
   bme_store->pressure = (bmp.readPressure() / 100.0); // conversion Pa -> hPa
   // bme.readAltitude(SEALEVELPRESSURE_HPA);
   bme_store->iaq = 0; // IAQ feature not present with BME280
+#elif defined HAS_BMP280
+    bme_store->temperature = bmp.readTemperature();
+  bme_store->pressure = (bmp.readPressure() / 100.0); // conversion Pa -> hPa
+  // bme.readAltitude(SEALEVELPRESSURE_HPA);
+  bme_store->iaq = 0; // IAQ feature not present with BMP280
+
 #endif
 } // bme_storedata()
 

--- a/src/cyclic.cpp
+++ b/src/cyclic.cpp
@@ -98,6 +98,10 @@ void doHousekeeping() {
 #elif defined HAS_BMP180
   ESP_LOGI(TAG, "BMP180 Temp: %.2f°C | Pressure: %.0f", bme_status.temperature,
            bme_status.pressure);
+#elif defined HAS_BMP280
+  ESP_LOGI(TAG, "BMP280 Temp: %.2f°C | Pressure: %.0f", bme_status.temperature,
+           bme_status.pressure);
+
 #endif
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -409,6 +409,8 @@ void setup() {
   strcat_P(features, " BME280");
 #elif defined HAS_BMP180
   strcat_P(features, " BMP180");
+#elif defined HAS_BMP280
+  strcat_P(features, " BMP280");
 #endif
   if (bme_init())
     ESP_LOGI(TAG, "BME sensor initialized");


### PR DESCRIPTION
This PR adds support for the BMP280 Sensor(https://www.bosch-sensortec.com/products/environmental-sensors/pressure-sensors/bmp280/) 