### PR TITLE
Added support for CYD (Cheap Yellow Display)

### DIFF
--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -22,6 +22,8 @@ LoLin32lite + [LoraNode32-Lite shield](https://github.com/hallard/LoLin32-Lite-L
 - Crowdsupply: [TinyPICO](https://www.crowdsupply.com/unexpected-maker/tinypico)
 - TTGO: [T-Display](https://www.aliexpress.com/item/33048962331.html)
 - TTGO: [T-Wristband](https://www.aliexpress.com/item/4000527495064.html)
+- CYD 2432S024 - in developmnent
+- [CYD 2432S028](https://www.aliexpress.com/item/1005004502250619.html) - in development
 - Generic ESP32
 
 *) supports microSD/TF-card for local logging of paxcounter data. SD/TF-card must be FAT32 formatted.

--- a/platformio_orig.ini
+++ b/platformio_orig.ini
@@ -36,6 +36,7 @@ halfile = ttgov21new.h
 ;halfile = m5core.h
 ;halfile = m5fire.h
 ;halfile = olimexpoeiso.h
+;halfile = cyd.h
 
 [platformio]
 ; upload firmware to board with usb cable

--- a/shared/hal/cyd.h
+++ b/shared/hal/cyd.h
@@ -17,15 +17,15 @@
 // #define TFT_TYPE DISPLAY_CYD        // For classic CYD (commented out by default)
 #define TFT_TYPE DISPLAY_CYD_24R    // For newer CYD 2.4" (defined below)
 
-// Provide a header-side definition for DISPLAY_CYD_24R so it matches
+// Provide a header-side definition for DISPLAY_CYD_24 so it matches
 // the newer bb_spi_lcd init signature for the CYD 2.4" module.
 // This way users can simply toggle the TFT_TYPE line above to pick the panel.
-#ifndef DISPLAY_CYD_24R
+#ifndef DISPLAY_CYD_24
 // Display dimensions (native orientation)
 #define MY_DISPLAY_WIDTH 320
 #define MY_DISPLAY_HEIGHT 240
 
-// SPI pins for CYD 2.4" module (match newer bb_spi_lcd DISPLAY_CYD_24R)
+// SPI pins for CYD 2.4" module
 #define TFT_MOSI GPIO_NUM_13   // SPI MOSI
 #define TFT_MISO GPIO_NUM_12   // SPI MISO
 #define TFT_SCLK GPIO_NUM_14   // SPI SCLK
@@ -36,7 +36,7 @@
 #define TFT_BL   GPIO_NUM_27   // LED back-light
 #define TFT_FREQUENCY 40000000
 
-#define DISPLAY_CYD_24R LCD_ST7789, FLAGS_INVERT, TFT_FREQUENCY, TFT_CS, TFT_DC, TFT_RST, TFT_BL, TFT_MISO, TFT_MOSI, TFT_SCLK
+#define DISPLAY_CYD_24 LCD_ST7789, FLAGS_INVERT, TFT_FREQUENCY, TFT_CS, TFT_DC, TFT_RST, TFT_BL, TFT_MISO, TFT_MOSI, TFT_SCLK
 #endif
 
 // If the user didn't uncomment a TFT_TYPE above, default to the classic preset

--- a/shared/hal/cyd.h
+++ b/shared/hal/cyd.h
@@ -1,0 +1,68 @@
+// clang-format off
+// upload_speed 115200
+// board esp32dev
+
+#ifndef _CYD24_H
+#define _CYD24_H
+
+#include <stdint.h>
+
+// Hardware related definitions for CYD boards
+
+#define VERBOSE 1       // set to 0 to silence the device, 1 enables additional debug output
+
+// Display Settings
+#define HAS_DISPLAY 2   // TFT-LCD
+// uncomment one of the following to select the CYD type
+// #define TFT_TYPE DISPLAY_CYD        // For classic CYD (commented out by default)
+#define TFT_TYPE DISPLAY_CYD_24R    // For newer CYD 2.4" (defined below)
+
+// Provide a header-side definition for DISPLAY_CYD_24R so it matches
+// the newer bb_spi_lcd init signature for the CYD 2.4" module.
+// This way users can simply toggle the TFT_TYPE line above to pick the panel.
+#ifndef DISPLAY_CYD_24R
+// Display dimensions (native orientation)
+#define MY_DISPLAY_WIDTH 320
+#define MY_DISPLAY_HEIGHT 240
+
+// SPI pins for CYD 2.4" module (match newer bb_spi_lcd DISPLAY_CYD_24R)
+#define TFT_MOSI GPIO_NUM_13   // SPI MOSI
+#define TFT_MISO GPIO_NUM_12   // SPI MISO
+#define TFT_SCLK GPIO_NUM_14   // SPI SCLK
+#define TFT_CS   GPIO_NUM_15   // Chip select control (CS)
+#define TFT_DC   GPIO_NUM_2      // Data/Command control (DC)
+// Module does not use a reset pin; indicate with -1 in init
+#define TFT_RST -1
+#define TFT_BL   GPIO_NUM_27   // LED back-light
+#define TFT_FREQUENCY 40000000
+
+#define DISPLAY_CYD_24R LCD_ST7789, FLAGS_INVERT, TFT_FREQUENCY, TFT_CS, TFT_DC, TFT_RST, TFT_BL, TFT_MISO, TFT_MOSI, TFT_SCLK
+#endif
+
+// If the user didn't uncomment a TFT_TYPE above, default to the classic preset
+#ifndef TFT_TYPE
+#define TFT_TYPE DISPLAY_CYD
+#endif
+
+
+// enable only if you want to store a local paxcount table on the device
+// Should use the SD card on device but there are issues with that
+/*
+#define HAS_SDCARD  1      // this board has an SD-card-reader/writer
+// Pins for SD-card
+#define SDCARD_CS    (5)
+#define SDCARD_MOSI  (23)
+#define SDCARD_MISO  (19)
+#define SDCARD_SCLK  (18)
+*/
+// The erros below are related to SD card initialization problems
+// I (16) src/sdcard.cpp: looking for SD-card...
+// E (16) spi: spi_bus_initialize(756): SPI bus already initialized.
+// E (17) src/sdcard.cpp: failed to initialize SPI bus
+
+#define DISABLE_BROWNOUT 1 // comment out if you want to keep brownout feature
+
+#define HAS_LED (16) // on board  LED
+#define HAS_BUTTON (0) // on board button
+
+#endif // _CYD24_H


### PR DESCRIPTION
From Issue #1034 
It's a cheap display based on ESP32.

You can either select
- 2.8 inch screen with `#define TFT_TYPE DISPLAY_CYD`
- Or a 2.4 inch one with `#define TFT_TYPE DISPLAY_CYD_24R`

Here is a link for it:
[2.4 inch CYD - tested](https://www.aliexpress.com/item/1005006625937360.html)
[2.8 inch CYD](https://www.aliexpress.com/item/1005004502250619.html)

## Features
- 2.4" touch screen  
- LED  
- Button
- SD card slot *(not working yet)*  
- There are 5 exposed GPIO pins so you can probably add a LoRa module to it.